### PR TITLE
Add ArgumentParser class that takes care of adding and processing --telstate and --name options

### DIFF
--- a/katsdptelstate/__init__.py
+++ b/katsdptelstate/__init__.py
@@ -1,4 +1,4 @@
-from .telescope_state import TelescopeState, InvalidKeyError, ImmutableKeyError
+from .telescope_state import TelescopeState, InvalidKeyError, ImmutableKeyError, ArgumentParser
 
 # Attempt to determine installed package version
 # borrowed from katpoint

--- a/katsdptelstate/test/test_telescope_state.py
+++ b/katsdptelstate/test/test_telescope_state.py
@@ -3,8 +3,9 @@
 import unittest
 import redis
 import os, time
+import mock
 
-from katsdptelstate import TelescopeState, InvalidKeyError, ImmutableKeyError
+from katsdptelstate import TelescopeState, InvalidKeyError, ImmutableKeyError, ArgumentParser
 
 class TestSDPTelescopeState(unittest.TestCase):
     @classmethod
@@ -61,3 +62,89 @@ class TestSDPTelescopeState(unittest.TestCase):
         self.ts.delete('test_key')
         self.ts.add('test_key',x)
         self.assertTrue((self.ts.test_key == x).all())
+
+@mock.patch('katsdptelstate.telescope_state.TelescopeState', autospec=True)
+class TestArgumentParser(unittest.TestCase):
+    def _stub_get(self, name):
+        if name == 'config':
+            return self.config
+        else:
+            raise KeyError
+
+    def setUp(self):
+        self.parser = ArgumentParser()
+        self.parser.add_argument('positional', type=str)
+        self.parser.add_argument('--int-arg', type=int, default=5)
+        self.parser.add_argument('--float-arg', type=float, default=3.5)
+        self.parser.add_argument('--no-default', type=str)
+        self.parser.add_argument('--bool-arg', action='store_true', default=False)
+        self.config = {
+            'int_arg': 10,
+            'float_arg': 4.5,
+            'no_default': 'telstate',
+            'bool_arg': True,
+            'not_arg': 'should not be seen',
+            'level1': {
+                'int_arg': 11,
+                'level2': {
+                    'float_arg': 12.5
+                }
+            }
+        }
+
+    def test_no_telstate(self, TelescopeState):
+        """Passing explicit arguments but no telescope model sets the arguments."""
+        args = self.parser.parse_args(['hello', '--int-arg=3', '--float-arg=2.5', '--no-default=test', '--bool-arg'])
+        self.assertIsNone(args.telstate)
+        self.assertEqual('', args.name)
+        self.assertEqual('hello', args.positional)
+        self.assertEqual(3, args.int_arg)
+        self.assertEqual(2.5, args.float_arg)
+        self.assertEqual('test', args.no_default)
+        self.assertEqual(True, args.bool_arg)
+
+    def test_no_telstate_defaults(self, TelescopeState):
+        """Passing no optional arguments sets those arguments"""
+        args = self.parser.parse_args(['hello'])
+        self.assertIsNone(args.telstate)
+        self.assertEqual('', args.name)
+        self.assertEqual('hello', args.positional)
+        self.assertEqual(5, args.int_arg)
+        self.assertEqual(3.5, args.float_arg)
+        self.assertIsNone(args.no_default)
+        self.assertEqual(False, args.bool_arg)
+
+    def test_telstate_no_name(self, TelescopeState):
+        """Passing --telstate but not --name loads from root config"""
+        TelescopeState.return_value.get = mock.MagicMock(side_effect=self._stub_get)
+        args = self.parser.parse_args(['hello', '--telstate=example.com'])
+        self.assertIs(TelescopeState.return_value, args.telstate)
+        self.assertEqual('', args.name)
+        self.assertEqual(10, args.int_arg)
+        self.assertEqual(4.5, args.float_arg)
+        self.assertEqual('telstate', args.no_default)
+        self.assertEqual(True, args.bool_arg)
+        self.assertNotIn('help', vars(args))
+        self.assertNotIn('not_arg', vars(args))
+
+    def test_telstate_nested(self, TelescopeState):
+        """Passing a nested name loads from all levels of the hierarchy"""
+        TelescopeState.return_value.get = mock.MagicMock(side_effect=self._stub_get)
+        args = self.parser.parse_args(['hello', '--telstate=example.com', '--name=level1.level2'])
+        self.assertIs(TelescopeState.return_value, args.telstate)
+        self.assertEqual('level1.level2', args.name)
+        self.assertEqual('hello', args.positional)
+        self.assertEqual(11, args.int_arg)
+        self.assertEqual(12.5, args.float_arg)
+        self.assertEqual('telstate', args.no_default)
+
+    def test_telstate_override(self, TelescopeState):
+        """Command-line parameters override telescope state"""
+        TelescopeState.return_value.get = mock.MagicMock(side_effect=self._stub_get)
+        args = self.parser.parse_args(['hello', '--int-arg=0', '--float-arg=0', '--telstate=example.com', '--name=level1.level2'])
+        self.assertIs(TelescopeState.return_value, args.telstate)
+        self.assertEqual('level1.level2', args.name)
+        self.assertEqual('hello', args.positional)
+        self.assertEqual(0, args.int_arg)
+        self.assertEqual(0.0, args.float_arg)
+        self.assertEqual('telstate', args.no_default)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 redis
+mock


### PR DESCRIPTION
This is an alternative to pull requests #3 and #4. It subclasses `argparse.ArgumentParser`with a version that takes care of
- adding the command-line options --telstate and --name
- extracting their values and connecting to the telescope state repository
- extracting defaults from the telescope state repository.

This also supersedes `override_local_defaults`, which should probably be deleted if we merge this.
@sratcliffe, I assume this is something you will review.
