### PR TITLE
Changed get_range to have return_format parameter which can be used to s...

### DIFF
--- a/katsdptelstate/telescope_state.py
+++ b/katsdptelstate/telescope_state.py
@@ -173,13 +173,9 @@ class TelescopeState(object):
             ret_vals = self._r.zrangebylex(key,"[{}".format(packed_st),"[{}".format(packed_et))
             ret_list = [self._strip(str_val) for str_val in ret_vals]
             
-        if return_format is None:
+        if return_format is not 'recarray':
             return ret_list
-        elif return_format is 'recarray':
-            val_shape = np.atleast_2d(ret_list)[0][0].shape
-            return np.array(ret_list, dtype=[('value', np.complex, val_shape), ('time', np.float)])
         else:
-            raise ValueError
-            
-                
-            
+            val_shape = np.array(np.atleast_2d(ret_list)[0][0]).shape
+            val_type = np.array(np.atleast_2d(ret_list)[0][0]).dtype
+            return np.array(ret_list, dtype=[('value', val_type, val_shape), ('time', np.float)])

--- a/katsdptelstate/test/test_telescope_state.py
+++ b/katsdptelstate/test/test_telescope_state.py
@@ -61,3 +61,28 @@ class TestSDPTelescopeState(unittest.TestCase):
         self.ts.delete('test_key')
         self.ts.add('test_key',x)
         self.assertTrue((self.ts.test_key == x).all())
+        
+    def test_return_format(self):
+        """Test recarray return format of get_range method:
+              Tests that values returned by db are identical to the input values."""
+        arr = [[1.,2.,3.],[0.,4.,0.],[10.,9.,7.]]
+        self.ts.delete('x')
+        self.ts.add('x',arr[0])
+        self.ts.add('x',arr[1])
+        self.ts.add('x',arr[2])
+        val = self.ts.get_range('x',st=0,return_format='recarray')['value']
+        self.assertTrue((val == arr).all())
+        
+    def test_return_format_type(self):
+        """Test recarray return format of get_range method:
+              Tests that values returned by db have identical types to the input values."""
+        arr = [[1.,2.,3.],[0.,4.,0.]]
+        arr_type = type(arr[0][0])
+        self.ts.delete('x')
+        self.ts.add('x',arr[0])
+        self.ts.add('x',arr[1])
+        val = self.ts.get_range('x',st=0,return_format='recarray')['value']
+        self.assertTrue(val.dtype == arr_type)
+
+        
+        


### PR DESCRIPTION
...pecify numpy recarry format for the output.

For return_format='recarray' the output array has keys 'time' and 'value'

Also - Simon - I added a bit of commenting at the beginning of the method. You can axe it is you want - was more me thinking through how it worked than anything else.

@sratcliffe 
