### PR TITLE
Added contains method to telstate, and corresponding test

### DIFF
--- a/katsdptelstate/telescope_state.py
+++ b/katsdptelstate/telescope_state.py
@@ -47,6 +47,9 @@ class TelescopeState(object):
         if val is None: raise KeyError
         return val
 
+    def __contains__(self, x):
+        return self.has_key(x)
+
     def send_message(self, data, channel=None):
         """Broadcast a message to all telescope model users."""
         if channel is None: channel = self._default_channel

--- a/katsdptelstate/test/test_telescope_state.py
+++ b/katsdptelstate/test/test_telescope_state.py
@@ -62,6 +62,11 @@ class TestSDPTelescopeState(unittest.TestCase):
         self.assertTrue(self.ts.has_key('test_key'))
         self.assertFalse(self.ts.has_key('nonexistent_test_key'))
 
+    def test_contains(self):
+        self.ts.add('test_key',1234.5)
+        self.assertTrue('test_key' in self.ts)
+        self.assertFalse('nonexistent_test_key' in self.ts)
+
     def test_return_format(self):
         """Test recarray return format of get_range method:
               Tests that values returned by db are identical to the input values."""


### PR DESCRIPTION
Allows us to use the syntax:
'key' in telstate

Why? Just because its neat and dictionary-ish :)
