### PR TITLE
Add socket timeout to catch connection errors

### DIFF
--- a/katsdptelstate/telescope_state.py
+++ b/katsdptelstate/telescope_state.py
@@ -20,7 +20,8 @@ class TelescopeState(object):
         if not isinstance(endpoint, Endpoint):
             endpoint = endpoint_parser(default_port=None)(endpoint)
         if endpoint.port is not None:
-            self._r = redis.StrictRedis(host=endpoint.host, port=endpoint.port, db=db)
+            self._r = redis.StrictRedis(host=endpoint.host, port=endpoint.port,
+                                        db=db, socket_timeout=5)
         else:
             self._r = redis.StrictRedis(host=endpoint.host, db=db)
         self._ps = self._r.pubsub(ignore_subscribe_messages=True)


### PR DESCRIPTION
It is sometimes tricky to determine if a redis server is available.
This adds a Timeout class using Unix signals a la
http://stackoverflow.com/a/22348885/942503, which wraps the first
command to redis during construction of the TelescopeState object.
Without it, the subscribe command hangs in the absence of a server
(at least on OS X).

I tried hard to raise a redis.ConnectionError instead of a custom
TimeoutError but this somehow interfered with the signals.
