### PR TITLE
Fix interpretation of address ranges to match ICDs

### DIFF
--- a/katsdptelstate/endpoint.py
+++ b/katsdptelstate/endpoint.py
@@ -93,7 +93,8 @@ def endpoint_list_parser(default_port, single_port=False):
     a comma-separated list, each element of which is of the form taken by
     :func:`endpoint_parser`. Optionally, the hostname may be followed by
     `+count`, where `count` is an integer specifying a number of sequential
-    IP addresses. This variation is only valid with IPv4 addresses.
+    IP addresses (in addition to the explicitly named one). This variation is
+    only valid with IPv4 addresses.
 
     If `single_port` is true, then it will reject any list that contains
     more than one distinct port number, as well as an empty list. This allows
@@ -109,11 +110,11 @@ def endpoint_list_parser(default_port, single_port=False):
             if pos != -1:
                 start = endpoint.host[:pos]
                 count = int(endpoint.host[pos+1:])
-                if count <= 0:
+                if count < 0:
                     raise ValueError('bad count {0}'.format(count))
                 try:
                     start_raw = struct.unpack('>I', socket.inet_aton(start))[0]
-                    for i in range(start_raw, start_raw + count):
+                    for i in range(start_raw, start_raw + count + 1):
                         host = socket.inet_ntoa(struct.pack('>I', i))
                         endpoints.append(Endpoint(host, endpoint.port))
                 except socket.error:

--- a/katsdptelstate/test/test_endpoint.py
+++ b/katsdptelstate/test/test_endpoint.py
@@ -45,9 +45,11 @@ class TestEndpointList(object):
             Endpoint('192.168.1.0', 1234),
             Endpoint('192.168.1.1', 1234),
             Endpoint('192.168.1.2', 1234),
+            Endpoint('192.168.1.3', 1234),
             Endpoint('10.0.255.255', 60),
             Endpoint('10.1.0.0', 60),
-            Endpoint('10.1.0.1', 60)
+            Endpoint('10.1.0.1', 60),
+            Endpoint('10.1.0.2', 60)
         ]
         assert_equal(expected, endpoints)
 


### PR DESCRIPTION
An address range like 1.2.3.4+3 is specified to mean 4 total addresses
(the given one plus an EXTRA 3), but endpoint.py was interpreting this
as 3 total addresses.
