### PR TITLE
Update version checking cult cargo from katpoint

### DIFF
--- a/katsdptelstate/__init__.py
+++ b/katsdptelstate/__init__.py
@@ -3,16 +3,14 @@ from .telescope_state import TelescopeState, InvalidKeyError, ImmutableKeyError,
 # Attempt to determine installed package version
 # borrowed from katpoint
 try:
-    import pkg_resources as _pkg_resources
+    import pip
 except ImportError:
     __version__ = "unknown"
 else:
     try:
-        dist = _pkg_resources.get_distribution("katsdptelstate")
-        # ver needs to be a list since tuples in Python <= 2.5 don't have
-        # a .index method.
-        ver = list(dist.parsed_version)
-        __version__ = "r%d" % int(ver[ver.index("*r") + 1])
-        del dist, ver
-    except (_pkg_resources.DistributionNotFound, ValueError, IndexError, TypeError):
+        dist = next(d for d in pip.get_installed_distributions()
+                    if d.key == "katsdptelstate")
+        __version__ = dist.version
+        del dist
+    except StopIteration:
         __version__ = "unknown"


### PR DESCRIPTION
The old version iterated over the result of pkg_resources.parse_version which
now triggers an ugly deprecation warning upon import. This version is cleaner,
but we really should be using something like katversion.
