### PR TITLE
Fixes to make telescope state work on Python 3

### DIFF
--- a/katsdptelstate/endpoint.py
+++ b/katsdptelstate/endpoint.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, division, absolute_import
 import socket
 import struct
 import netifaces


### PR DESCRIPTION
I want to try to make all the new Mesos code I write work on Python 3, which means the dependencies (currently just katsdptelstate) need to work on Python 3 too. This is the minimal set of fixes I needed to make the unit tests pass, so there might be other lurking problems.

This is obviously low priority.