### PR TITLE
Enable Python 3 unit tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 #!groovy
 
-@Library('katsdpjenkins@python3') _
+@Library('katsdpjenkins') _
 katsdp.setDependencies(['ska-sa/katsdpdockerbase/master'])
 katsdp.standardBuild(python3: true)
 katsdp.mail('schwardt@ska.ac.za')


### PR DESCRIPTION
Note: don't merge as-is. The `@python3` branch of katsdpjenkins needs to be switched back once ska-sa/katsdpjenkins#1 is merged.