### PR TITLE
Add TelescopeState.clear method

### DIFF
--- a/katsdptelstate/telescope_state.py
+++ b/katsdptelstate/telescope_state.py
@@ -110,7 +110,7 @@ class TelescopeState(object):
         """Remove a key, and all values, from the model."""
         return self._r.delete(key)
 
-    def flush(self):
+    def clear(self):
         """Remove all keys."""
         return self._r.flushdb()
 

--- a/katsdptelstate/test/test_telescope_state.py
+++ b/katsdptelstate/test/test_telescope_state.py
@@ -42,10 +42,10 @@ class TestSDPTelescopeState(unittest.TestCase):
         self.ts.delete('test_key')
         self.ts.delete('test_key')
 
-    def test_flush(self):
+    def test_clear(self):
         self.ts.add('test_key', 1234.5)
         self.ts.add('test_key_rt', 2345.6)
-        self.ts.flush()
+        self.ts.clear()
         self.assertEqual([], self.ts.keys())
 
     def test_return_pickle(self):


### PR DESCRIPTION
It removes all keys from the database. This is primarily intended for
test code, where it can prevent state leaks due to fakeredis keeping
global instead of per-object state. It will also be used in the
katsdpcal simulator though.