### PR TITLE
Allow supplemental keys to be written to the RDB file

### DIFF
--- a/katsdptelstate/rdb_writer.py
+++ b/katsdptelstate/rdb_writer.py
@@ -47,7 +47,7 @@ class RDBWriter(object):
             self._r = redis.StrictRedis(host=endpoint.host, port=endpoint.port)
         self.logger = logging.getLogger(__name__)
 
-    def save(self, filename, keys=None, supplemental_dumps=None):
+    def save(self, filename, keys=None, supplemental_dumps=[]):
         """Encodes specified keys from the RDB file into binary
         string representation and writes these to a file.
 


### PR DESCRIPTION
Helper to allow inserting 'stream_name' and 'stream_type' from the metawriter without actually adding them to the live telstate.