### PR TITLE
Allow any telstate to use load_from_file

### DIFF
--- a/katsdptelstate/rdb_reader.py
+++ b/katsdptelstate/rdb_reader.py
@@ -1,0 +1,54 @@
+from __future__ import print_function, division, absolute_import
+import logging
+import os.path
+
+from rdbtools import RdbParser, RdbCallback
+
+
+logger = logging.getLogger(__name__)
+
+
+class _Callback(RdbCallback):
+    def __init__(self, client):
+        super(_Callback, self).__init__(string_escape=None)
+        self.client = client
+        self._zset = []
+        self.n_keys = 0
+
+    def set(self, key, value, expiry, info):
+        self.client.set(key, value, expiry)
+        self.n_keys += 1
+
+    def start_sorted_set(self, key, length, expiry, info):
+        self._zset = []
+        self.n_keys += 1
+
+    def zadd(self, key, score, member):
+        self._zset.append(score)
+        self._zset.append(member)
+
+    def end_sorted_set(self, key):
+        self.client.zadd(key, *self._zset)
+        self._zset = []
+
+
+def load_from_file(client, filename):
+    """Load keys from the specified RDB-compatible dump file.
+
+    Parameters
+    ---------
+    client : :class:`redis.StrictRedis`-like
+        Redis client wrapper
+    filename : str
+        Filename of .rdb file to import
+
+    Returns
+    -------
+    int
+        Number of keys loaded
+    """
+    callback = _Callback(client)
+    parser = RdbParser(callback)
+    logger.debug("Loading data from RDB dump of %d bytes", os.path.getsize(filename))
+    parser.parse(filename)
+    return callback.n_keys

--- a/katsdptelstate/telescope_state.py
+++ b/katsdptelstate/telescope_state.py
@@ -17,6 +17,11 @@ import redis
 
 from .endpoint import Endpoint, endpoint_parser
 from .tabloid_redis import TabloidRedis
+try:
+    from . import rdb_reader
+except ImportError as _rdb_reader_import_error:
+    rdb_reader = None
+
 
 logger = logging.getLogger(__name__)
 PICKLE_PROTOCOL = 0         #: Version of pickle protocol to use
@@ -148,15 +153,11 @@ class TelescopeState(object):
     def load_from_file(self, filename):
         """Load keys from a Redis-compatible RDB file.
 
-        Telstate must be using a :class:`~katsdptelstate.tabloid_redis.TabloidRedis`
-        backend for this load to succeed, otherwise NotImplementedError is raised.
-
-        Will raise NameError if the rdbtools package is not installed.
+        Will raise ImportError if the rdbtools package is not installed.
         """
-        if not isinstance(self._r, TabloidRedis):
-            raise NotImplementedError(
-                "Load from file can only be used with a TabloidRedis backend. Please build telstate with an empty endpoint.")
-        keys_loaded = self._r.load_from_file(filename)
+        if rdb_reader is None:
+            raise _rdb_reader_import_error
+        keys_loaded = rdb_reader.load_from_file(self._r, filename)
         logger.info("Loading {} keys from {}".format(keys_loaded, filename))
         return keys_loaded
 


### PR DESCRIPTION
The restriction that only TabloidRedis-backed telstate can use
load_from_file was completely artificial, caused by the code structure.
I've split out the load_from_file member into a free function in
rdb_reader.py.

I've also fixed a bug: it was returning the total number of keys after
loading, instead of the number loaded, which could be different if there
was already content.