### PR TITLE
Ensure that redis-py is < 3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 fakeredis
 ipaddress
-msgpack==0.5.6
+msgpack
 netifaces
 numpy
 redis

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(name='katsdptelstate',
       python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, <4',
       setup_requires=['katversion'],
       use_katversion=True,
-      install_requires=['redis>=2.10.5', 'fakeredis>=0.10.2',
+      install_requires=['redis>=2.10.5,<3', 'fakeredis>=0.10.2',
                         'netifaces', 'ipaddress', 'msgpack', 'numpy'],
       extras_require={'rdb': ['rdbtools', 'python-lzf']},
       tests_require=['mock', 'rdbtools', 'six'])


### PR DESCRIPTION
redis-py 3.0 breaks backwards compatibility, particularly with ZADD
(which we use extensively). In future we should probably update telstate
to use it, but for now just avoid it.

Also remove version pin on msgpack in requirements.txt since it's now
pinned in base.