### PR TITLE
Add __setitem__ and __setattr__ to katsdptelstate

### DIFF
--- a/katsdptelstate/telescope_state.py
+++ b/katsdptelstate/telescope_state.py
@@ -413,6 +413,18 @@ class TelescopeState(object):
     def __getitem__(self, key):
         return self._get(key)
 
+    def __setattr__(self, key, value):
+        if key.startswith('_'):
+            super(TelescopeState, self).__setattr__(key, value)
+        elif key in self.__class__.__dict__:
+            raise AttributeError("The specified key already exists as a "
+                                 "class method and thus cannot be used.")
+        else:
+            self.add(key, value, immutable=True)
+
+    def __setitem__(self, key, value):
+        self.add(key, value, immutable=True)
+
     def __contains__(self, key_name):
         """Check to see if the specified key exists in the database."""
         key_name = _as_bytes(key_name)

--- a/katsdptelstate/test/test_telescope_state.py
+++ b/katsdptelstate/test/test_telescope_state.py
@@ -296,6 +296,20 @@ class TestTelescopeState(unittest.TestCase):
         self.assertTrue('test_key' in self.ts)
         self.assertFalse('nonexistent_test_key' in self.ts)
 
+    def test_setattr(self):
+        self.ts.test_key = 'foo'
+        self.assertEqual(self.ts['test_key'], 'foo')
+        self.assertTrue(self.ts.is_immutable('test_key'))
+        with self.assertRaises(AttributeError):
+            self.ts.root = 'root is a method'
+        self.ts._internal = 'bar'
+        self.assertFalse('_internal' in self.ts)
+
+    def test_setitem(self):
+        self.ts['test_key'] = 'foo'
+        self.assertEqual(self.ts['test_key'], 'foo')
+        self.assertTrue(self.ts.is_immutable('test_key'))
+
     def test_time_range(self):
         self.ts.delete('test_key')
         self.ts.add('test_key', 8192, 1)


### PR DESCRIPTION
Both of them are equivalent to `add` with immutable=True. This could
actually make a lot of code less verbose. Compare:
```python
ts.add('foo', 'value', immutable=True)
ts['foo'] = 'value'
```

I decided not to implement `__delitem__` because the semantics are not
as clear-cut: `delete` deletes from all namespaces, so it deletes a
variable number of keys, while one intuitively expects `__delitem__` to
delete exactly one key. Deleting keys is also discouraged anyway.

Closes SR-116.