### PR TITLE
Make compatible with fakeredis 1.0+

### DIFF
--- a/katsdptelstate/telescope_state.py
+++ b/katsdptelstate/telescope_state.py
@@ -338,7 +338,12 @@ class TelescopeState(object):
             if not isinstance(endpoint, Endpoint):
                 endpoint = endpoint_parser(default_port=None)(endpoint)
             if not endpoint.host:
-                self._r = TabloidRedis(db=db, singleton=False)
+                try:
+                    self._r = TabloidRedis(db=db, singleton=False)
+                except TypeError:
+                    # Fakeredis 1.0 removed the singleton option, and defaults
+                    # to having unique state per instance.
+                    self._r = TabloidRedis(db=db)
             else:
                 redis_kwargs = dict(host=endpoint.host, db=db, socket_timeout=5)
                 # If no port is provided, redis will pick its default port


### PR DESCRIPTION
I'm shortly going to release fakeredis 1.0, which removes the singleton
option (and makes it default).

setup.py still specifies <1.0 because 1.0 is much slower (particularly a
problem when using it to access data in an RDB file, where it is at
least 5x slower and uses almost double the RAM). But this will at least
avoid crashes if someone forcibly installs a newer version.