### PR TITLE
Prepare for v0.7

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2015-2018, National Research Foundation (Square Kilometre Array)
+Copyright (c) 2015-2019, National Research Foundation (Square Kilometre Array)
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -7,6 +7,7 @@ History
 * Introduce backends and add in-memory backend as alternative to redis (#71, #72)
 * Simplify setting attributes via `__setitem__` (#68)
 * Let keys be bytes internally, but allow specification as unicode strings (#63)
+* The GitHub repository is now public as well
 
 0.6 (2018-05-10)
 ----------------

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -5,7 +5,7 @@ History
 ----------------
 * Introduce encodings and add msgpack encoding as alternative to pickle (#64, #65)
 * Introduce backends and add in-memory backend as alternative to redis (#71, #72)
-* Simplify setting attributes via __setitem__ (#68)
+* Simplify setting attributes via `__setitem__` (#68)
 * Let keys be bytes internally, but allow specification as unicode strings (#63)
 
 0.6 (2018-05-10)

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -1,0 +1,13 @@
+History
+=======
+
+0.7 (2019-02-12)
+----------------
+* Introduce encodings and add msgpack encoding as alternative to pickle (#64, #65)
+* Introduce backends and add in-memory backend as alternative to redis (#71, #72)
+* Simplify setting attributes via __setitem__ (#68)
+* Let keys be bytes internally, but allow specification as unicode strings (#63)
+
+0.6 (2018-05-10)
+----------------
+* Initial release of katsdptelstate

--- a/katsdptelstate/__init__.py
+++ b/katsdptelstate/__init__.py
@@ -1,3 +1,19 @@
+################################################################################
+# Copyright (c) 2015-2019, National Research Foundation (Square Kilometre Array)
+#
+# Licensed under the BSD 3-Clause License (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy
+# of the License at
+#
+#   https://opensource.org/licenses/BSD-3-Clause
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
 from .telescope_state import (TelescopeState, ConnectionError, InvalidKeyError,
                               ImmutableKeyError, TimeoutError, CancelledError,
                               DecodeError, EncodeError,

--- a/katsdptelstate/compat.py
+++ b/katsdptelstate/compat.py
@@ -1,3 +1,19 @@
+################################################################################
+# Copyright (c) 2019, National Research Foundation (Square Kilometre Array)
+#
+# Licensed under the BSD 3-Clause License (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy
+# of the License at
+#
+#   https://opensource.org/licenses/BSD-3-Clause
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
 from __future__ import print_function, division, absolute_import
 
 import itertools

--- a/katsdptelstate/endpoint.py
+++ b/katsdptelstate/endpoint.py
@@ -1,3 +1,19 @@
+################################################################################
+# Copyright (c) 2015-2019, National Research Foundation (Square Kilometre Array)
+#
+# Licensed under the BSD 3-Clause License (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy
+# of the License at
+#
+#   https://opensource.org/licenses/BSD-3-Clause
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
 from __future__ import print_function, division, absolute_import
 
 import socket

--- a/katsdptelstate/memory.py
+++ b/katsdptelstate/memory.py
@@ -1,3 +1,19 @@
+################################################################################
+# Copyright (c) 2019, National Research Foundation (Square Kilometre Array)
+#
+# Licensed under the BSD 3-Clause License (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy
+# of the License at
+#
+#   https://opensource.org/licenses/BSD-3-Clause
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
 from __future__ import print_function, division, absolute_import
 
 import bisect

--- a/katsdptelstate/rdb_reader.py
+++ b/katsdptelstate/rdb_reader.py
@@ -1,3 +1,19 @@
+################################################################################
+# Copyright (c) 2018-2019, National Research Foundation (Square Kilometre Array)
+#
+# Licensed under the BSD 3-Clause License (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy
+# of the License at
+#
+#   https://opensource.org/licenses/BSD-3-Clause
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
 from __future__ import print_function, division, absolute_import
 
 import logging

--- a/katsdptelstate/rdb_utility.py
+++ b/katsdptelstate/rdb_utility.py
@@ -1,3 +1,19 @@
+################################################################################
+# Copyright (c) 2018-2019, National Research Foundation (Square Kilometre Array)
+#
+# Licensed under the BSD 3-Clause License (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy
+# of the License at
+#
+#   https://opensource.org/licenses/BSD-3-Clause
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
 import struct
 
 

--- a/katsdptelstate/rdb_writer.py
+++ b/katsdptelstate/rdb_writer.py
@@ -1,3 +1,19 @@
+################################################################################
+# Copyright (c) 2018-2019, National Research Foundation (Square Kilometre Array)
+#
+# Licensed under the BSD 3-Clause License (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy
+# of the License at
+#
+#   https://opensource.org/licenses/BSD-3-Clause
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
 import logging
 import os
 

--- a/katsdptelstate/redis.py
+++ b/katsdptelstate/redis.py
@@ -1,3 +1,19 @@
+################################################################################
+# Copyright (c) 2019, National Research Foundation (Square Kilometre Array)
+#
+# Licensed under the BSD 3-Clause License (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy
+# of the License at
+#
+#   https://opensource.org/licenses/BSD-3-Clause
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
 from __future__ import print_function, division, absolute_import
 
 import contextlib

--- a/katsdptelstate/tabloid_redis.py
+++ b/katsdptelstate/tabloid_redis.py
@@ -1,3 +1,19 @@
+################################################################################
+# Copyright (c) 2018-2019, National Research Foundation (Square Kilometre Array)
+#
+# Licensed under the BSD 3-Clause License (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy
+# of the License at
+#
+#   https://opensource.org/licenses/BSD-3-Clause
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
 import logging
 import struct
 

--- a/katsdptelstate/telescope_state.py
+++ b/katsdptelstate/telescope_state.py
@@ -1,3 +1,19 @@
+################################################################################
+# Copyright (c) 2015-2019, National Research Foundation (Square Kilometre Array)
+#
+# Licensed under the BSD 3-Clause License (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy
+# of the License at
+#
+#   https://opensource.org/licenses/BSD-3-Clause
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
 from __future__ import print_function, division, absolute_import
 
 import struct

--- a/katsdptelstate/test/test_endpoint.py
+++ b/katsdptelstate/test/test_endpoint.py
@@ -1,3 +1,19 @@
+################################################################################
+# Copyright (c) 2015-2019, National Research Foundation (Square Kilometre Array)
+#
+# Licensed under the BSD 3-Clause License (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy
+# of the License at
+#
+#   https://opensource.org/licenses/BSD-3-Clause
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
 """Tests for the Endpoint class."""
 
 from nose.tools import assert_equal, assert_not_equal, assert_raises

--- a/katsdptelstate/test/test_rdb_handling.py
+++ b/katsdptelstate/test/test_rdb_handling.py
@@ -1,3 +1,19 @@
+################################################################################
+# Copyright (c) 2018-2019, National Research Foundation (Square Kilometre Array)
+#
+# Licensed under the BSD 3-Clause License (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy
+# of the License at
+#
+#   https://opensource.org/licenses/BSD-3-Clause
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
 """Tests for the RDB handling (reading and writing) functionality."""
 
 from __future__ import print_function, division, absolute_import

--- a/katsdptelstate/test/test_telescope_state.py
+++ b/katsdptelstate/test/test_telescope_state.py
@@ -1,4 +1,21 @@
+################################################################################
+# Copyright (c) 2015-2019, National Research Foundation (Square Kilometre Array)
+#
+# Licensed under the BSD 3-Clause License (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy
+# of the License at
+#
+#   https://opensource.org/licenses/BSD-3-Clause
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
 # coding: utf-8
+
 """Tests for the sdp telescope state client."""
 
 from __future__ import print_function, division, absolute_import

--- a/katsdptelstate/test/test_telescope_state.py
+++ b/katsdptelstate/test/test_telescope_state.py
@@ -1,3 +1,5 @@
+# coding: utf-8
+
 ################################################################################
 # Copyright (c) 2015-2019, National Research Foundation (Square Kilometre Array)
 #
@@ -13,8 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
-
-# coding: utf-8
 
 """Tests for the sdp telescope state client."""
 

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@
 # limitations under the License.
 ################################################################################
 
-import os
+import os.path
 
 from setuptools import setup, find_packages
 

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,21 @@
 #!/usr/bin/env python
 
+################################################################################
+# Copyright (c) 2015-2019, National Research Foundation (Square Kilometre Array)
+#
+# Licensed under the BSD 3-Clause License (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy
+# of the License at
+#
+#   https://opensource.org/licenses/BSD-3-Clause
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
 import os
 
 from setuptools import setup, find_packages

--- a/setup.py
+++ b/setup.py
@@ -23,10 +23,12 @@ from setuptools import setup, find_packages
 
 here = os.path.abspath(os.path.dirname(__file__))
 readme = open(os.path.join(here, 'README.rst')).read()
+news = open(os.path.join(here, 'NEWS.rst')).read()
+long_description = readme + '\n\n' + news
 
 setup(name='katsdptelstate',
       description='Karoo Array Telescope - Telescope State Client',
-      long_description=readme,
+      long_description=long_description,
       author='Simon Ratcliffe',
       author_email='sratcliffe@ska.ac.za',
       packages=find_packages(),

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ import os
 from setuptools import setup, find_packages
 
 
-here = os.path.abspath(os.path.dirname(__file__))
+here = os.path.dirname(__file__)
 readme = open(os.path.join(here, 'README.rst')).read()
 news = open(os.path.join(here, 'NEWS.rst')).read()
 long_description = readme + '\n\n' + news


### PR DESCRIPTION
Here I had to add copyright headers to all source files... And a changelog.

It's a good thing we are releasing this, since the GitHub repo is still private and the new katdal v0.12 would break otherwise.