### PR TITLE
Switch the default telstate encoding to msgpack

### DIFF
--- a/katsdptelstate/telescope_state.py
+++ b/katsdptelstate/telescope_state.py
@@ -51,7 +51,7 @@ ENCODING_PICKLE = b'\x80'
 ENCODING_MSGPACK = b'\xff'
 
 #: Default encoding for :func:`encode_value`
-ENCODING_DEFAULT = ENCODING_PICKLE
+ENCODING_DEFAULT = ENCODING_MSGPACK
 
 #: All encodings that can be used with :func:`encode_value`
 ALLOWED_ENCODINGS = frozenset([ENCODING_PICKLE, ENCODING_MSGPACK])


### PR DESCRIPTION
This is possible now that katdal 0.12 and katsdptelstate 0.7 have been
released, making it possible to read this data.

See SR-1366.