### PR TITLE
Make MemoryBackend the default

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-fakeredis
+fakeredis==1.0.1
 ipaddress
 msgpack
 netifaces

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ msgpack
 netifaces
 numpy
 redis
+six                        # via fakeredis
+sortedcontainers==2.1.0    # via fakeredis

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,8 @@ setup(name='katsdptelstate',
       python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, <4',
       setup_requires=['katversion'],
       use_katversion=True,
-      install_requires=['redis>=2.10.5', 'fakeredis>=0.10.2,<1.0',
+      install_requires=['redis>=2.10.5',
                         'netifaces', 'ipaddress', 'msgpack', 'numpy'],
-      extras_require={'rdb': ['rdbtools', 'python-lzf']},
-      tests_require=['mock', 'rdbtools', 'six'])
+      extras_require={'rdb': ['rdbtools', 'python-lzf'],
+                      'fakeredis': ['fakeredis>=0.10.2']},
+      tests_require=['mock', 'rdbtools', 'six', 'fakeredis>=1.0.1'])

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,4 +5,3 @@ nose
 pbr
 python-lzf==0.2.4
 rdbtools==0.1.12
-six


### PR DESCRIPTION
There were some fairly substantial changes to the unit tests, mostly
because I noticed that the load_from_file tests weren't in great shape.
They're now split into a lower-level (redis layer) test of
tabloid_redis, rdb_reader, rdb_writer; and a higher-level test of
TelescopeState.load_from_file (per backend).

Also make fakeredis an optional dependency, since it's now only needed
for testing and for a few special cases (like constructing keys in
memory to write to an RDB file), and remove the pin on <1.0 (1.0 is
slower, but no longer on the critical path). For testing, require 1.0.1
to avoid the need to handle the `singleton` argument differently between
0.x and 1.0, and 1.0.1 fixes a bug that was crashing the test.