### PR TITLE
Make it possible to write to RDB from a MemoryBackend

### DIFF
--- a/katsdptelstate/memory.py
+++ b/katsdptelstate/memory.py
@@ -28,6 +28,7 @@ except ImportError as _rdbtools_import_error:
     RdbParser = None
 
 from .telescope_state import Backend, ImmutableKeyError
+from .rdb_utility import dump_string, dump_zset
 
 
 _INF = float('inf')
@@ -221,3 +222,12 @@ class MemoryBackend(Backend):
             start_pos -= 1
         end_pos = self._bisect(items, end_time, True, include_end)
         return [self.split_timestamp(value) for value in items[start_pos:end_pos]]
+
+    def dump(self, key):
+        value = self._data.get(key)
+        if value is None:
+            return None
+        elif isinstance(value, bytes):
+            return dump_string(value)
+        else:
+            return dump_zset(value)

--- a/katsdptelstate/rdb_utility.py
+++ b/katsdptelstate/rdb_utility.py
@@ -87,7 +87,7 @@ def dump_zset(data):
         enc = [b'\x03' + encode_len(len(data))]
          # for inscrutable reasons the length here is half the number of actual entries (i.e. scores are ignored)
         for entry in data:
-            enc.append(encode_len(len(entry)) + entry + '\x010')
+            enc.append(encode_len(len(entry)) + entry + b'\x010')
              # interleave entries and scores directly
              # for now, scores are kept fixed at integer zero since float
              # encoding is breaking for some reason and is not needed for telstate

--- a/katsdptelstate/rdb_utility.py
+++ b/katsdptelstate/rdb_utility.py
@@ -17,6 +17,10 @@
 import struct
 
 
+# Version 6 (first two bytes), and a zero checksum
+DUMP_POSTFIX = b"\x06\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+
+
 def encode_len(length):
     """Encodes the specified length as 1,2 or 5 bytes of
        RDB specific length encoded byte.
@@ -42,3 +46,68 @@ def encode_prev_length(length):
     if length < 254:
         return struct.pack('B', length)
     return b'\xfe' + struct.pack(">q", length)
+
+
+def dump_string(data):
+    """Encode a binary string as per redis DUMP command"""
+    type_specifier = b'\x00'
+    encoded_length = encode_len(len(data))
+    return type_specifier + encoded_length + data + DUMP_POSTFIX
+
+
+def dump_zset(data):
+    """Encode a set of values as a redis zset, as per redis DUMP command
+       All scores are assumed to be zero.
+
+       Redis uses both LZF and Ziplist format depending on various arcane heuristics.
+       For maximum compatibility we use LZF and Ziplist as this supports really large values well, at the expense of
+       additional overhead for small values.
+
+       A zset dump thus takes the following form:
+
+            (length encoding)(ziplist string envelope)
+
+       The ziplist string envelope itself is an LZF compressed string with the following form:
+       (format descriptions are provided in the description for each component)
+
+            (bytes in list '<i')(offset to tail '<i')(number of entries '<h')(entry 1)(entry 2)(entry 2N)(terminator 0xFF)
+
+       The entries themselves are encoded as follows:
+
+            (previous entry length 1byte or 5bytes)(entry length - up to 5 bytes as per length encoding)(value)
+
+       The entries alternate between zset values and scores, so there should always be 2N entries in the decode.
+    """
+    entry_count = 2 * len(data)
+
+    # The entries counter for ziplists is encoded as 2 bytes, if we exceed this limit
+    # we fall back to making a simple set. Redis of course makes the decision point using
+    # only 7 out of the 16 bits available and switches at 127 entries...
+    if entry_count > 127:
+        enc = [b'\x03' + encode_len(len(data))]
+         # for inscrutable reasons the length here is half the number of actual entries (i.e. scores are ignored)
+        for entry in data:
+            enc.append(encode_len(len(entry)) + entry + '\x010')
+             # interleave entries and scores directly
+             # for now, scores are kept fixed at integer zero since float
+             # encoding is breaking for some reason and is not needed for telstate
+        enc.append(DUMP_POSTFIX)
+        return b"".join(enc)
+
+    type_specifier = b'\x0c'
+    raw_entries = []
+    previous_length = b'\x00'
+    # loop through each entry in the data interleaving encoded values and scores (all set to zero)
+    for entry in data:
+        enc = previous_length + encode_len(len(entry)) + entry
+        raw_entries.append(enc)
+        previous_length = encode_prev_length(len(enc))
+        raw_entries.append(previous_length + b'\xf1')
+         # scores are encoded using a special length schema which supports direct integer addressing
+         # 4 MSB set implies direct unsigned integer in 4 LSB (minus 1). Hence \xf1 is integer 0
+        previous_length = b'\x02'
+    encoded_entries = b"".join(raw_entries) + b'\xff'
+    zl_length = 10 + len(encoded_entries)
+     # account for the known 10 bytes worth of length descriptors when calculating envelope length
+    zl_envelope = struct.pack('<i', zl_length) + struct.pack('<i', zl_length - 3) + struct.pack('<h', entry_count) + encoded_entries
+    return b'\x0c' + encode_len(len(zl_envelope)) + zl_envelope + DUMP_POSTFIX

--- a/katsdptelstate/redis.py
+++ b/katsdptelstate/redis.py
@@ -162,3 +162,6 @@ class RedisBackend(Backend):
                         else:
                             value, timestamp = self.split_timestamp(message['data'])
                             timeout = yield (key, value, timestamp)
+
+    def dump(self, key):
+        return self.client.dump(key)

--- a/katsdptelstate/tabloid_redis.py
+++ b/katsdptelstate/tabloid_redis.py
@@ -19,10 +19,7 @@ import struct
 
 from fakeredis import FakeStrictRedis
 
-from .rdb_utility import encode_len, encode_prev_length
-
-
-DUMP_POSTFIX = b"\x06\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+from .rdb_utility import dump_string, dump_zset
 
 
 class TabloidRedis(FakeStrictRedis):
@@ -42,73 +39,17 @@ class TabloidRedis(FakeStrictRedis):
            Note: This follows the DUMP command in Redis itself which produces output
            that is similarly encoded to an RDB, but not exactly the same.
 
-           String types are encoded simply with a length specified (as documented in encode_len) followed directly by the
-           value bytestring.
+           ZSet scores are ignored and encoded as zero.
 
-           Zset types are more complex and Redis uses both LZF and Ziplist format depending on various arcane heuristics.
-           For maximum compatibility we use LZF and Ziplist as this supports really large values well, at the expense of
-           additional overhead for small values.
-
-           A zset dump thus takes the following form:
-
-                (length encoding)(ziplist string envelope)
-
-           The ziplist string envelope itself is an LZF compressed string with the following form:
-           (format descriptions are provided in the description for each component)
-
-                (bytes in list '<i')(offset to tail '<i')(number of entries '<h')(entry 1)(entry 2)(entry 2N)(terminator 0xFF)
-
-           The entries themselves are encoded as follows:
-
-                (previous entry length 1byte or 5bytes)(entry length - up to 5 bytes as per length encoding)(value)
-
-           The entries alternate between zset values and scores, so there should always be 2N entries in the decode.
-
-           Returns None is key not found
+           Returns None if `key` not found.
         """
 
-        type_specifier = b'\x00'
         key_type = self.type(key)
         if key_type == b'none':
             return None
         if key_type == b'zset':
-            type_specifier = b'\x0c'
-            data = self.zrange(key, 0, -1, withscores=True)
-            entry_count = 2 * len(data)
-
-            # The entries counter for ziplists is encoded as 2 bytes, if we exceed this limit
-            # we fall back to making a simple set. Redis of course makes the decision point using
-            # only 7 out of the 16 bits available and switches at 127 entries...
-            if entry_count > 127:
-                enc = [b'\x03' + encode_len(len(data))]
-                 # for inscrutable reasons the length here is half the number of actual entries (i.e. scores are ignored)
-                for entry in data:
-                    enc.append(encode_len(len(entry[0])) + entry[0] + '\x010')
-                     # interleave entries and scores directly
-                     # for now, scores are kept fixed at integer zero since float
-                     # encoding is breaking for some reason and is not needed for telstate
-                enc.append(DUMP_POSTFIX)
-                return b"".join(enc)
-
-            raw_entries = []
-            previous_length = b'\x00'
-            # loop through each entry in the data interleaving encoded values and scores (all set to zero)
-            for entry in data:
-                enc = previous_length + encode_len(len(entry[0])) + entry[0]
-                raw_entries.append(enc)
-                previous_length = encode_prev_length(len(enc))
-                raw_entries.append(previous_length + b'\xf1')
-                 # scores are encoded using a special length schema which supports direct integer addressing
-                 # 4 MSB set implies direct unsigned integer in 4 LSB (minus 1). Hence \xf1 is integer 0
-                previous_length = b'\x02'
-            encoded_entries = b"".join(raw_entries) + b'\xff'
-            zl_length = 10 + len(encoded_entries)
-             # account for the known 10 bytes worth of length descriptors when calculating envelope length
-            zl_envelope = struct.pack('<i', zl_length) + struct.pack('<i', zl_length - 3) + struct.pack('<h', entry_count) + encoded_entries
-            return b'\x0c' + encode_len(len(zl_envelope)) + zl_envelope + DUMP_POSTFIX
-        else:
-            type_specifier = b'\x00'
-            val = self.get(key)
-            encoded_length = encode_len(len(val))
-            return type_specifier + encoded_length + val + DUMP_POSTFIX
+            data = self.zrange(key, 0, -1)
+            return dump_zset(data)
+        if key_type == b'string':
+            return dump_string(self.get(key))
         raise NotImplementedError("Unsupported key type {}. Must be either string or zset".format(key_type))

--- a/katsdptelstate/telescope_state.py
+++ b/katsdptelstate/telescope_state.py
@@ -415,6 +415,10 @@ class Backend(object):
         """Same as :meth:`TelescopeState.get_message`"""
         raise NotImplementedError
 
+    def dump(self, key):
+        """Return a key in the same format as the Redis DUMP command, or None if not present"""
+        raise NotImplementedError
+
     def monitor_keys(self, keys):
         """Report changes to keys in `keys`.
 

--- a/katsdptelstate/test/test_rdb_handling.py
+++ b/katsdptelstate/test/test_rdb_handling.py
@@ -89,14 +89,12 @@ class TestLoadFromFile(unittest.TestCase):
         return TelescopeState()
 
     def test_load_from_file(self):
-        # Create a TabloidRedis-backed telstate so we can write to file
-        tr = TabloidRedis()
-        write_ts = TelescopeState(RedisBackend(tr))
+        write_ts = self.make_telescope_state()
         write_ts['immutable'] = ['some value']
         write_ts.add('mutable', 'first', 12.0)
         write_ts.add('mutable', 'second', 15.5)
         # Write data to file
-        rdb_writer = RDBWriter(client=tr)
+        rdb_writer = RDBWriter(client=write_ts.backend)
         rdb_writer.save(self.filename)
 
         # Load it back into some backend
@@ -113,4 +111,4 @@ class TestLoadFromFile(unittest.TestCase):
 class TestLoadFromFileRedis(unittest.TestCase):
     """Test :meth:`TelescopeState.load_from_file` with redis backend."""
     def make_telescope_state(self):
-        return TelescopeState(RedisBackend(fakeredis.FakeStrictRedis()))
+        return TelescopeState(RedisBackend(TabloidRedis()))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-fakeredis
+fakeredis==1.0.1
 ipaddress
 msgpack
 netifaces

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ msgpack
 netifaces
 numpy
 redis
+six                        # via fakeredis
+sortedcontainers==2.1.0    # via fakeredis

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,8 @@ setup(name='katsdptelstate',
       python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, <4',
       setup_requires=['katversion'],
       use_katversion=True,
-      install_requires=['redis>=2.10.5', 'fakeredis>=0.10.2,<1.0',
+      install_requires=['redis>=2.10.5',
                         'netifaces', 'ipaddress', 'msgpack', 'numpy'],
-      extras_require={'rdb': ['rdbtools', 'python-lzf']},
-      tests_require=['mock', 'rdbtools', 'six'])
+      extras_require={'rdb': ['rdbtools', 'python-lzf'],
+                      'fakeredis': ['fakeredis>=0.10.2']},
+      tests_require=['mock', 'rdbtools', 'six', 'fakeredis>=1.0.1'])

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,4 +5,3 @@ nose
 pbr
 python-lzf==0.2.4
 rdbtools==0.1.12
-six


### PR DESCRIPTION
The Backend API gains a `dump` function, which for redis is just a
wrapper around the redis-py `dump` function, but on MemoryBackend
constructs the dump. The TabloidRedis code mostly moves into rdb_utility
so that it can be shared by MemoryBackend. RDBWriter can now take a
Backend instead of a redis client (and in future that should probably be
preferred).

At this point TabloidRedis has very little value, and is preserved only
for backwards compatibility until katsdpmetawriter no longer depends on
it.