### PR TITLE
Warn when loading pickled data

### DIFF
--- a/katsdptelstate/telescope_state.py
+++ b/katsdptelstate/telescope_state.py
@@ -255,7 +255,7 @@ def decode_value(value, allow_pickle=None):
         If false, :const:`ENCODING_PICKLE` is disabled. This may be useful for
         security as pickle decoding can execute arbitrary code. If the default
         of ``None`` is used, it is controlled by the
-        KATSDPTELSTATE_ALLOW_PICKLE environment variable. Is that is not set,
+        KATSDPTELSTATE_ALLOW_PICKLE environment variable. If that is not set,
         the default is true (with a warning), but it may change to false in future.
 
     Raises

--- a/katsdptelstate/telescope_state.py
+++ b/katsdptelstate/telescope_state.py
@@ -30,6 +30,7 @@ import sys
 import io
 import os
 import warnings
+import threading
 
 import redis
 import msgpack
@@ -64,21 +65,51 @@ MSGPACK_EXT_NUMPY_SCALAR = 4      # dtype descriptor then raw value
 
 _INF = float('inf')
 
-ALLOW_PICKLE = True
-WARN_ON_PICKLE = True
+_allow_pickle = True
+_warn_on_pickle = True
+_pickle_lock = threading.Lock()       # Protects _allow_pickle, _warn_on_pickle
+
+
+PICKLE_WARNING = ('The telescope state contains pickled values. This is a security risk, '
+                  'but is allowed because MeerKAT data up to March 2019 uses it. '
+                  'You can suppress this warning by setting KATSDPTELSTATE_ALLOW_PICKLE=1 '
+                  'in the environment, or disable pickles by setting '
+                  'KATSDPTELSTATE_ALLOW_PICKLE=0.')
+
+
+def set_allow_pickle(allow, warn):
+    """Control whether pickles are allowed.
+
+    This overrides the defaults which are determined from the environment.
+
+    Parameters
+    ----------
+    allow : bool
+        If true, allow pickles to be loaded.
+    warn : bool
+        If true, warn the user the next time a pickle is loaded (after which
+        it becomes false). This has no effect if `allow` is false.
+    """
+    global _allow_pickle, _warn_on_pickle
+
+    with _pickle_lock:
+        _allow_pickle = allow
+        _warn_on_pickle = warn
 
 
 def _init_allow_pickle():
-    global ALLOW_PICKLE, WARN_ON_PICKLE
-
-    allow = os.environ.get('KATSDPTELSTATE_ALLOW_PICKLE')
-    if allow == '1':
-        WARN_ON_PICKLE = False
-    elif allow == '0':
-        ALLOW_PICKLE = False
-        WARN_ON_PICKLE = False
-    elif allow is not None:
-        warnings.warn('Unknown value {!r} for KATSDPTELSTATE_ALLOW_PICKLE'.format(allow))
+    env = os.environ.get('KATSDPTELSTATE_ALLOW_PICKLE')
+    allow = True
+    warn = True
+    if env == '1':
+        allow = True
+        warn = False
+    elif env == '0':
+        allow = False
+        warn = False
+    elif env is not None:
+        warnings.warn('Unknown value {!r} for KATSDPTELSTATE_ALLOW_PICKLE'.format(env))
+    set_allow_pickle(allow, warn)
 
 
 _init_allow_pickle()
@@ -256,7 +287,9 @@ def decode_value(value, allow_pickle=None):
         security as pickle decoding can execute arbitrary code. If the default
         of ``None`` is used, it is controlled by the
         KATSDPTELSTATE_ALLOW_PICKLE environment variable. If that is not set,
-        the default is true (with a warning), but it may change to false in future.
+        the default is true (with a warning), but it may change to false in
+        future. The default may also be overridden with
+        :func:`set_allow_pickle`.
 
     Raises
     ------
@@ -265,6 +298,8 @@ def decode_value(value, allow_pickle=None):
     DecodeError
         if there was an error in the encoding of `value`
     """
+    global _warn_on_pickle
+
     if not value:
         raise DecodeError('empty value')
     elif value[:1] == ENCODING_MSGPACK:
@@ -274,14 +309,11 @@ def decode_value(value, allow_pickle=None):
             raise DecodeError(str(error))
     elif value[:1] <= ENCODING_PICKLE:
         if allow_pickle is None:
-            allow_pickle = ALLOW_PICKLE
-            if WARN_ON_PICKLE:
-                warnings.warn(
-                    'The telescope state contains pickled values. This is a security risk, '
-                    'but is allowed because MeerKAT data up to March 2019 uses it. '
-                    'You can suppress this warning by setting KATSDPTELSTATE_ALLOW_PICKLE=1 '
-                    'in the environment, or disable pickles by setting '
-                    'KATSDPTELSTATE_ALLOW_PICKLE=0.')
+            with _pickle_lock:
+                allow_pickle = _allow_pickle
+                if _warn_on_pickle:
+                    warnings.warn(PICKLE_WARNING)
+                    _warn_on_pickle = False
         if allow_pickle:
             try:
                 return _pickle_loads(value)

--- a/katsdptelstate/telescope_state.py
+++ b/katsdptelstate/telescope_state.py
@@ -312,7 +312,7 @@ def decode_value(value, allow_pickle=None):
             with _pickle_lock:
                 allow_pickle = _allow_pickle
                 if _warn_on_pickle:
-                    warnings.warn(PICKLE_WARNING)
+                    warnings.warn(PICKLE_WARNING, FutureWarning)
                     _warn_on_pickle = False
         if allow_pickle:
             try:

--- a/katsdptelstate/test/test_telescope_state.py
+++ b/katsdptelstate/test/test_telescope_state.py
@@ -114,6 +114,8 @@ class _TestEncoding(unittest.TestCase):
                 pass
 
 
+@mock.patch('katsdptelstate.telescope_state.ALLOW_PICKLE', True)
+@mock.patch('katsdptelstate.telescope_state.WARN_ON_PICKLE', False)
 class TestEncodingPickle(_TestEncoding):
     encoding = ENCODING_PICKLE
 
@@ -242,6 +244,8 @@ class TestTelescopeState(unittest.TestCase):
         with self.assertRaises(ImmutableKeyError):
             self.ts.add('test_mutable', 2345.6, immutable=True)
 
+    @mock.patch('katsdptelstate.telescope_state.ALLOW_PICKLE', True)
+    @mock.patch('katsdptelstate.telescope_state.WARN_ON_PICKLE', False)
     def test_immutable_same_value_str(self):
         self.ts.add('test_bytes', b'caf\xc3\xa9', immutable=True)
         self.ts.add('test_bytes', b'caf\xc3\xa9', immutable=True)

--- a/katsdptelstate/test/test_telescope_state.py
+++ b/katsdptelstate/test/test_telescope_state.py
@@ -90,6 +90,7 @@ class _TestEncoding(unittest.TestCase):
         decoded = decode_value(encoded)
         self.assertTrue(np.isnan(decoded))
 
+    @mock.patch('katsdptelstate.telescope_state._allow_pickle', False)
     def test_fuzz(self):
         if self.encoding == ENCODING_PICKLE:
             raise unittest.SkipTest("Pickles will exhaust memory or crash given a bad pickle")
@@ -114,8 +115,8 @@ class _TestEncoding(unittest.TestCase):
                 pass
 
 
-@mock.patch('katsdptelstate.telescope_state.ALLOW_PICKLE', True)
-@mock.patch('katsdptelstate.telescope_state.WARN_ON_PICKLE', False)
+@mock.patch('katsdptelstate.telescope_state._allow_pickle', True)
+@mock.patch('katsdptelstate.telescope_state._warn_on_pickle', False)
 class TestEncodingPickle(_TestEncoding):
     encoding = ENCODING_PICKLE
 
@@ -244,8 +245,8 @@ class TestTelescopeState(unittest.TestCase):
         with self.assertRaises(ImmutableKeyError):
             self.ts.add('test_mutable', 2345.6, immutable=True)
 
-    @mock.patch('katsdptelstate.telescope_state.ALLOW_PICKLE', True)
-    @mock.patch('katsdptelstate.telescope_state.WARN_ON_PICKLE', False)
+    @mock.patch('katsdptelstate.telescope_state._allow_pickle', True)
+    @mock.patch('katsdptelstate.telescope_state._warn_on_pickle', False)
     def test_immutable_same_value_str(self):
         self.ts.add('test_bytes', b'caf\xc3\xa9', immutable=True)
         self.ts.add('test_bytes', b'caf\xc3\xa9', immutable=True)


### PR DESCRIPTION
An environment variable can be used to either suppress the warning (opt
in to pickles) or to make it an exception (opt out of pickles).