### PR TITLE
 Load RDB files from file-like objects

### DIFF
--- a/katsdptelstate/memory.py
+++ b/katsdptelstate/memory.py
@@ -23,8 +23,8 @@ import logging
 from .telescope_state import Backend, ImmutableKeyError
 from .rdb_utility import dump_string, dump_zset
 try:
+    from rdbtools import RdbCallback
     from . import rdb_reader
-    from .rdb_reader import RdbCallback
 except ImportError as _rdb_reader_import_error:
     RdbCallback = object     # So that _Callback can still be defined
     rdb_reader = None

--- a/katsdptelstate/rdb_reader.py
+++ b/katsdptelstate/rdb_reader.py
@@ -55,15 +55,18 @@ def load_from_file(callback, file):
 
     Parameters
     ----------
-    callback : :class:`rdbtools.RdbCallback`-like
-        Backend-specific callback that stores keys as RDB file is parsed
+    callback : :class:`rdbtools.RdbCallback`-like with `n_keys` attribute
+        Backend-specific callback that stores keys as RDB file is parsed. In
+        addition to the interface of :class:`rdbtools.RdbCallback` it should
+        have an `n_keys` attribute that reflects the number of keys loaded from
+        the RDB file.
     file : str or file-like object
         Filename of .rdb file to import, or object representing contents of RDB
 
     Returns
     -------
     int
-        Number of keys loaded
+        Number of keys loaded (obtained from :attr:`callback.n_keys`)
     """
     try:
         size = os.path.getsize(file)

--- a/katsdptelstate/rdb_reader.py
+++ b/katsdptelstate/rdb_reader.py
@@ -68,17 +68,15 @@ def load_from_file(callback, file):
     try:
         size = os.path.getsize(file)
     except TypeError:
-        start_pos = file.tell()
-        file.seek(0, 2)
-        size = file.tell() - start_pos
-        file.seek(start_pos)
-    except AttributeError:
-        size = -1   # File object does not support seeking
-    logger.debug("Loading data from RDB dump of %s bytes",
-                 str(size) if size >= 0 else 'unknown')
+        # One could maybe seek() and tell() on file object but is it worth it?
+        size = 'unknown'
+    logger.debug("Loading data from RDB dump of %s bytes", size)
     parser = RdbParser(callback)
     try:
-        parser.parse(file)
+        fd = open(file, 'rb')
     except TypeError:
         parser.parse_fd(file)
+    else:
+        with fd:
+            parser.parse_fd(fd)
     return callback.n_keys

--- a/katsdptelstate/redis.py
+++ b/katsdptelstate/redis.py
@@ -17,7 +17,6 @@
 from __future__ import print_function, division, absolute_import
 
 import contextlib
-import struct
 
 import redis
 
@@ -104,7 +103,7 @@ class RedisBackend(Backend):
     def add_mutable(self, key, value, timestamp):
         str_val = self.pack_timestamp(timestamp) + value
         with _handle_wrongtype():
-            ret = zadd(self.client, key, {str_val: 0})
+            zadd(self.client, key, {str_val: 0})
         self.client.publish(b'update/' + key, str_val)
 
     def get_range(self, key, start_time, end_time, include_previous, include_end):

--- a/katsdptelstate/redis.py
+++ b/katsdptelstate/redis.py
@@ -58,10 +58,11 @@ class RedisBackend(Backend):
             # redis.ConnectionError: good host, bad port
             raise ConnectionError("could not connect to redis server: {}".format(e))
 
-    def load_from_file(self, filename):
+    def load_from_file(self, file):
         if rdb_reader is None:
             raise _rdb_reader_import_error
-        return rdb_reader.load_from_file(self.client, filename)
+        callback = rdb_reader.Callback(self.client)
+        return rdb_reader.load_from_file(callback, file)
 
     def __contains__(self, key):
         return self.client.exists(key)

--- a/katsdptelstate/tabloid_redis.py
+++ b/katsdptelstate/tabloid_redis.py
@@ -15,7 +15,6 @@
 ################################################################################
 
 import logging
-import struct
 
 from fakeredis import FakeStrictRedis
 

--- a/katsdptelstate/telescope_state.py
+++ b/katsdptelstate/telescope_state.py
@@ -311,7 +311,7 @@ class Backend(object):
       the timestamps are non-negative finite floats and the values are
       :class:`bytes`.
     """
-    def load_from_file(self, filename):
+    def load_from_file(self, file):
         """Implements :meth:`TelescopeState.load_from_file`."""
         raise NotImplementedError
 
@@ -576,13 +576,13 @@ class TelescopeState(object):
     def backend(self):
         return self._backend
 
-    def load_from_file(self, filename):
-        """Load keys from a Redis-compatible RDB file.
+    def load_from_file(self, file):
+        """Load keys from a Redis-compatible RDB file (as filename or object).
 
         Will raise ImportError if the rdbtools package is not installed.
         """
-        keys_loaded = self._backend.load_from_file(filename)
-        logger.info("Loading {} keys from {}".format(keys_loaded, filename))
+        keys_loaded = self._backend.load_from_file(file)
+        logger.info("Loading {} keys from {}".format(keys_loaded, file))
         return keys_loaded
 
     def view(self, name, add_separator=True, exclusive=False):

--- a/katsdptelstate/test/test_rdb_handling.py
+++ b/katsdptelstate/test/test_rdb_handling.py
@@ -18,20 +18,15 @@
 
 from __future__ import print_function, division, absolute_import
 
-import time
 import unittest
-import struct
 import shutil
 import os
 import tempfile
-
-import fakeredis
 
 from katsdptelstate.rdb_writer import RDBWriter
 from katsdptelstate.rdb_reader import load_from_file, Callback
 from katsdptelstate.tabloid_redis import TabloidRedis
 from katsdptelstate.compat import zadd
-from katsdptelstate.memory import MemoryBackend
 from katsdptelstate.redis import RedisBackend
 from katsdptelstate import TelescopeState
 

--- a/katsdptelstate/test/test_rdb_handling.py
+++ b/katsdptelstate/test/test_rdb_handling.py
@@ -28,7 +28,7 @@ import tempfile
 import fakeredis
 
 from katsdptelstate.rdb_writer import RDBWriter
-from katsdptelstate.rdb_reader import load_from_file
+from katsdptelstate.rdb_reader import load_from_file, Callback
 from katsdptelstate.tabloid_redis import TabloidRedis
 from katsdptelstate.compat import zadd
 from katsdptelstate.memory import MemoryBackend
@@ -61,15 +61,14 @@ class TestRDBHandling(unittest.TestCase):
         self.assertEqual(self.rdb_writer.save(self.base('broken.rdb'), keys=['does_not_exist'])[0], 0)
 
         local_tr = TabloidRedis()
-        load_from_file(local_tr, self.base('all.rdb'))
-        self.assertEqual(load_from_file(local_tr, self.base('all.rdb')), 2)
+        self.assertEqual(load_from_file(Callback(local_tr), self.base('all.rdb')), 2)
         self.assertEqual(set(local_tr.keys()), {b'write', b'writezl'})
         self.assertEqual(local_tr.get('write'), test_str)
         vec = local_tr.zrange('writezl', 0, -1, withscores=True)
         self.assertEqual(vec, [(b'first', 0.0), (b'second', 0.0), (b'third\n\0', 0.0)])
 
         local_tr = TabloidRedis()
-        load_from_file(local_tr, self.base('one.rdb'))
+        load_from_file(Callback(local_tr), self.base('one.rdb'))
         self.assertEqual(local_tr.keys(), [b'writezl'])
         vec = local_tr.zrange('writezl', 0, -1, withscores=True)
         self.assertEqual(vec, [(b'first', 0.0), (b'second', 0.0), (b'third\n\0', 0.0)])
@@ -79,7 +78,7 @@ class TestRDBHandling(unittest.TestCase):
         self.rdb_writer.save(self.base('zset.rdb'))
 
         local_tr = TabloidRedis()
-        load_from_file(local_tr, self.base('zset.rdb'))
+        load_from_file(Callback(local_tr), self.base('zset.rdb'))
         self.assertEqual(local_tr.keys(), [b'my_zset'])
         vec = local_tr.zrange('my_zset', 0, -1, withscores=True)
         self.assertEqual(vec, [(item, 0.0) for item in items])
@@ -113,6 +112,16 @@ class TestLoadFromFile(unittest.TestCase):
     def make_telescope_state(self):
         return TelescopeState()
 
+    def load_from_file_and_check(self, file):
+        # Load RDB file back into some backend
+        read_ts = self.make_telescope_state()
+        read_ts.load_from_file(file)
+        self.assertEqual(read_ts.keys(), [b'immutable', b'mutable'])
+        self.assertTrue(read_ts.is_immutable('immutable'))
+        self.assertEqual(read_ts['immutable'], ['some value'])
+        self.assertEqual(read_ts.get_range('mutable', st=0),
+                         [('first', 12.0), ('second', 15.5)])
+
     def test_load_from_file(self):
         write_ts = self.make_telescope_state()
         write_ts['immutable'] = ['some value']
@@ -121,16 +130,9 @@ class TestLoadFromFile(unittest.TestCase):
         # Write data to file
         rdb_writer = RDBWriter(client=write_ts.backend)
         rdb_writer.save(self.filename)
-
-        # Load it back into some backend
-        read_ts = self.make_telescope_state()
-        read_ts.load_from_file(self.filename)
-        self.assertEqual(read_ts.keys(), [b'immutable', b'mutable'])
-        self.assertTrue(read_ts.is_immutable('immutable'))
-        self.assertEqual(read_ts['immutable'], ['some value'])
-        self.assertEqual(
-            read_ts.get_range('mutable', st=0),
-            [('first', 12.0), ('second', 15.5)])
+        # Check loading from filenames and file-like objects
+        self.load_from_file_and_check(self.filename)
+        self.load_from_file_and_check(open(self.filename, 'rb'))
 
 
 class TestLoadFromFileRedis(unittest.TestCase):

--- a/katsdptelstate/test/test_telescope_state.py
+++ b/katsdptelstate/test/test_telescope_state.py
@@ -34,7 +34,6 @@ from katsdptelstate import (TelescopeState, InvalidKeyError, ImmutableKeyError,
                             encode_value, decode_value,
                             ENCODING_PICKLE, ENCODING_MSGPACK)
 from katsdptelstate.memory import MemoryBackend
-from katsdptelstate.redis import RedisBackend
 
 
 class _TestEncoding(unittest.TestCase):


### PR DESCRIPTION
This extends `TelescopeState.load_from_file` to load RDB files from file-like objects (as well as from filenames). This supports the ability to load RDB files directly from the Ceph store into memory.

Change the interface of `rdb_reader.load_from_file` so that it accepts a callback object instead of a client object. This lets the memory and Redis backends share the same function. In the case of a file object, get the size by seeking to the end of the file.

This supports JIRA ticket SR-1443.