### PR TITLE
 Improve error message if RDB file is invalid

### DIFF
--- a/katsdptelstate/__init__.py
+++ b/katsdptelstate/__init__.py
@@ -16,7 +16,7 @@
 
 from .telescope_state import (TelescopeState, ConnectionError, InvalidKeyError,
                               ImmutableKeyError, TimeoutError, CancelledError,
-                              DecodeError, EncodeError,
+                              DecodeError, EncodeError, RdbParseError,
                               PICKLE_PROTOCOL, encode_value, decode_value,
                               ALLOWED_ENCODINGS, ENCODING_DEFAULT,
                               ENCODING_PICKLE, ENCODING_MSGPACK)

--- a/katsdptelstate/memory.py
+++ b/katsdptelstate/memory.py
@@ -25,7 +25,7 @@ from .rdb_utility import dump_string, dump_zset
 try:
     from . import rdb_reader
     from .rdb_reader import BackendCallback
-except ImportError as _rdb_reader_import_error:
+except ImportError as _rdb_reader_import_error:   # noqa: F841
     rdb_reader = None
     BackendCallback = object     # So that MemoryCallback can still be defined
 
@@ -105,7 +105,7 @@ def _compile_pattern(pattern):
 
 
 class MemoryCallback(BackendCallback):
-    """Callback that stores keys in :class:`MemoryBackend` data structure."""
+    """RDB callback that stores keys in :class:`MemoryBackend` data structure."""
     def __init__(self, data):
         super(MemoryCallback, self).__init__()
         self.data = data
@@ -142,7 +142,7 @@ class MemoryBackend(Backend):
 
     def load_from_file(self, file):
         if rdb_reader is None:
-            raise _rdb_reader_import_error
+            raise _rdb_reader_import_error   # noqa: F821
         return rdb_reader.load_from_file(MemoryCallback(self._data), file)
 
     def __contains__(self, key):

--- a/katsdptelstate/memory.py
+++ b/katsdptelstate/memory.py
@@ -110,6 +110,7 @@ class _Callback(RdbCallback):
         super(_Callback, self).__init__(string_escape=None)
         self.data = data
         self.n_keys = 0
+        self.client_busy = False
 
     def set(self, key, value, expiry, info):
         self.data[key] = value

--- a/katsdptelstate/memory.py
+++ b/katsdptelstate/memory.py
@@ -26,8 +26,8 @@ try:
     from . import rdb_reader
     from .rdb_reader import BackendCallback
 except ImportError as _rdb_reader_import_error:
-    BackendCallback = object     # So that MemoryCallback can still be defined
     rdb_reader = None
+    BackendCallback = object     # So that MemoryCallback can still be defined
 
 
 _INF = float('inf')

--- a/katsdptelstate/rdb_reader.py
+++ b/katsdptelstate/rdb_reader.py
@@ -15,6 +15,7 @@
 ################################################################################
 
 from __future__ import print_function, division, absolute_import
+from future.utils import raise_from
 
 import logging
 import os.path
@@ -56,10 +57,11 @@ def _parse_rdb_file(parser, fd, filename=None):
     """Apply RDB parser to file descriptor, raising RdbParseError on error."""
     try:
         parser.parse_fd(fd)
-    except Exception as err:
-        if err.args == ('verify_magic_string', 'Invalid File Format'):
+    except Exception as exc:
+        if exc.args == ('verify_magic_string', 'Invalid File Format'):
             name = repr(filename) if filename else 'object'
-            raise RdbParseError('Invalid RDB file {}'.format(name))
+            err = RdbParseError('Invalid RDB file {}'.format(name))
+            raise_from(err, exc)
         raise
 
 

--- a/katsdptelstate/rdb_reader.py
+++ b/katsdptelstate/rdb_reader.py
@@ -15,7 +15,7 @@
 ################################################################################
 
 from __future__ import print_function, division, absolute_import
-from future.utils import raise_from
+from six import raise_from
 
 import logging
 import os.path

--- a/katsdptelstate/rdb_reader.py
+++ b/katsdptelstate/rdb_reader.py
@@ -59,13 +59,13 @@ class Callback(RdbCallback):
         self._zset = {}
 
 
-def _parse_rdb_file(parser, fd, filename=None):
+def _parse_rdb_file(parser, callback, fd, filename=None):
     """Apply RDB parser to file descriptor, raising RdbParseError on error."""
     try:
         parser.parse_fd(fd)
     except Exception as exc:
         # Don't remap exception to RdbParseError if it originates from callback
-        if parser._callback.client_busy:
+        if callback.client_busy:
             raise
         raise_from(RdbParseError(filename), exc)
 
@@ -103,8 +103,8 @@ def load_from_file(callback, file):
     try:
         fd = open(file, 'rb')
     except TypeError:
-        _parse_rdb_file(parser, file)
+        _parse_rdb_file(parser, callback, file)
     else:
         with fd:
-            _parse_rdb_file(parser, fd, file)
+            _parse_rdb_file(parser, callback, fd, file)
     return callback.n_keys

--- a/katsdptelstate/redis.py
+++ b/katsdptelstate/redis.py
@@ -60,7 +60,7 @@ class RedisBackend(Backend):
     def load_from_file(self, file):
         if rdb_reader is None:
             raise _rdb_reader_import_error
-        callback = rdb_reader.Callback(self.client)
+        callback = rdb_reader.RedisCallback(self.client)
         return rdb_reader.load_from_file(callback, file)
 
     def __contains__(self, key):

--- a/katsdptelstate/redis.py
+++ b/katsdptelstate/redis.py
@@ -25,7 +25,7 @@ from . import compat
 try:
     from . import rdb_reader
     from .rdb_reader import BackendCallback
-except ImportError as _rdb_reader_import_error:
+except ImportError as _rdb_reader_import_error:   # noqa: F841
     rdb_reader = None
     BackendCallback = object     # So that RedisCallback can still be defined
 
@@ -35,7 +35,7 @@ _MESSAGE_CHANNEL = b'tm_info'
 
 
 class RedisCallback(BackendCallback):
-    """Callback that stores keys in :class:`redis.StrictRedis`-like client."""
+    """RDB callback that stores keys in :class:`redis.StrictRedis`-like client."""
     def __init__(self, client):
         super(RedisCallback, self).__init__()
         self.client = client
@@ -88,7 +88,7 @@ class RedisBackend(Backend):
 
     def load_from_file(self, file):
         if rdb_reader is None:
-            raise _rdb_reader_import_error
+            raise _rdb_reader_import_error   # noqa: F821
         return rdb_reader.load_from_file(RedisCallback(self.client), file)
 
     def __contains__(self, key):

--- a/katsdptelstate/telescope_state.py
+++ b/katsdptelstate/telescope_state.py
@@ -120,6 +120,10 @@ class ConnectionError(TelstateError):
     """The initial connection to the Redis server failed."""
 
 
+class RdbParseError(TelstateError):
+    """Error parsing RDB file."""
+
+
 class InvalidKeyError(TelstateError):
     """A key collides with a class attribute"""
 

--- a/katsdptelstate/telescope_state.py
+++ b/katsdptelstate/telescope_state.py
@@ -661,6 +661,17 @@ class TelescopeState(object):
     def load_from_file(self, file):
         """Load keys from a Redis-compatible RDB snapshot file.
 
+        Redis keys are extracted sequentially from the RDB file and inserted
+        directly into the backend without any checks and ignoring the view.
+        It is therefore a bad idea to insert keys that already exist in telstate
+        and this will lead to undefined behaviour. The standard approach is
+        to call this method on an empty telstate.
+
+        If there is an error reading or parsing the RDB file (indicating either
+        a broken file or a non-RDB file), an `RdbParseError` is raised. Errors
+        raised while opening the file (like `OSError`) and errors raised by the
+        backend itself (like redis errors) can also occur.
+
         Parameters
         ----------
         file : str or file object

--- a/katsdptelstate/telescope_state.py
+++ b/katsdptelstate/telescope_state.py
@@ -122,6 +122,12 @@ class ConnectionError(TelstateError):
 
 class RdbParseError(TelstateError):
     """Error parsing RDB file."""
+    def __init__(self, filename=None):
+        self.filename = filename
+
+    def __str__(self):
+        name = repr(self.filename) if self.filename else 'object'
+        return 'Invalid RDB file {}'.format(name)
 
 
 class InvalidKeyError(TelstateError):

--- a/katsdptelstate/telescope_state.py
+++ b/katsdptelstate/telescope_state.py
@@ -659,9 +659,24 @@ class TelescopeState(object):
         return self._backend
 
     def load_from_file(self, file):
-        """Load keys from a Redis-compatible RDB file (as filename or object).
+        """Load keys from a Redis-compatible RDB snapshot file.
 
-        Will raise ImportError if the rdbtools package is not installed.
+        Parameters
+        ----------
+        file : str or file object
+            Filename or file object representing RDB file
+
+        Returns
+        -------
+        keys_loaded : int
+            Number of keys loaded from RDB file into telstate
+
+        Raises
+        ------
+        ImportError
+            If the rdbtools package is not installed
+        RdbParseError
+            If the file could not be parsed (truncated / malformed / not RDB)
         """
         keys_loaded = self._backend.load_from_file(file)
         logger.info("Loading {} keys from {}".format(keys_loaded, file))

--- a/katsdptelstate/test/test_rdb_handling.py
+++ b/katsdptelstate/test/test_rdb_handling.py
@@ -133,6 +133,9 @@ class TestLoadFromFile(unittest.TestCase):
         file.read(1)
         with self.assertRaises(RdbParseError):
             self.load_from_file_and_check(file)
+        # Check what happens if file does not exist
+        with self.assertRaises(OSError):
+            self.load_from_file_and_check(self.filename + '.nonexistent')
 
 
 class TestLoadFromFileRedis(unittest.TestCase):

--- a/katsdptelstate/test/test_rdb_handling.py
+++ b/katsdptelstate/test/test_rdb_handling.py
@@ -28,7 +28,7 @@ from katsdptelstate.rdb_reader import load_from_file, Callback
 from katsdptelstate.tabloid_redis import TabloidRedis
 from katsdptelstate.compat import zadd
 from katsdptelstate.redis import RedisBackend
-from katsdptelstate import TelescopeState
+from katsdptelstate import TelescopeState, RdbParseError
 
 
 class TestRDBHandling(unittest.TestCase):
@@ -128,6 +128,11 @@ class TestLoadFromFile(unittest.TestCase):
         # Check loading from filenames and file-like objects
         self.load_from_file_and_check(self.filename)
         self.load_from_file_and_check(open(self.filename, 'rb'))
+        # Check that malformed RDB file raises the appropriate exception
+        file = open(self.filename, 'rb')
+        file.read(1)
+        with self.assertRaises(RdbParseError):
+            self.load_from_file_and_check(file)
 
 
 class TestLoadFromFileRedis(unittest.TestCase):

--- a/katsdptelstate/test/test_rdb_handling.py
+++ b/katsdptelstate/test/test_rdb_handling.py
@@ -27,10 +27,10 @@ import redis
 import fakeredis
 
 from katsdptelstate.rdb_writer import RDBWriter
-from katsdptelstate.rdb_reader import load_from_file, RedisCallback
+from katsdptelstate.rdb_reader import load_from_file
 from katsdptelstate.tabloid_redis import TabloidRedis
 from katsdptelstate.compat import zadd
-from katsdptelstate.redis import RedisBackend
+from katsdptelstate.redis import RedisBackend, RedisCallback
 from katsdptelstate import TelescopeState, RdbParseError
 
 


### PR DESCRIPTION
The `rdbtools` exceptions are basic Exceptions with specific arguments. In the case of an invalid file format with no REDIS magic string, turn this into a more readable `TelstateError` instead. This simplifies `katdal` error handling (no need to catch the exception and then parse it too).

I was wondering whether I should catch `io.UnsupportedOperation` and convert it into `RdbParseError` as well. This occurs when the file exists but is empty or truncated.