### PR TITLE
RDB writer cleanup

### DIFF
--- a/katsdptelstate/rdb_writer.py
+++ b/katsdptelstate/rdb_writer.py
@@ -54,11 +54,11 @@ class RDBWriter(object):
         ----------
         filename : str
             Destination filename. Will be opened in 'wb'.
-        keys : list
-            A list of the keys to extract from Redis and include in the dump.
+        keys : sequence of str or bytes, optional
+            The keys to extract from Redis and include in the dump.
             Keys that don't exist will not raise an Exception, only a log message.
             None (default) includes all keys.
-        supplemental_dumps : list
+        supplemental_dumps : sequence of bytes, optional
             A list of encoded supplemental key/values in string form to be included
             in the RDB dump.
 
@@ -103,7 +103,7 @@ class RDBWriter(object):
         return self._encode_item(key, self.client.dump(_ensure_binary(key)))
 
     def _encode_item(self, key, key_dump):
-        """Returns a binary string containing an RDB encoded key and value.
+        """Returns a binary string containing an RDB-encoded key and value.
 
         First byte is used to indicate the encoding used for the value of this key.
         This is essentially just the Redis type.
@@ -162,16 +162,16 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     endpoint = args.redis
-    logger.info("Connecting to Redis instance at {}".format(endpoint))
+    logger.info("Connecting to Redis instance at %s", endpoint)
     client = redis.StrictRedis(host=endpoint.host, port=endpoint.port)
     rdb_writer = RDBWriter(client)
-    logger.info("Saving keys to RDB file {}".format(args.outfile))
+    logger.info("Saving keys to RDB file %s", args.outfile)
     keys = args.keys
     if keys is not None:
         keys = keys.split(",")
     keys_written, keys_failed = rdb_writer.save(args.outfile, keys)
     if keys_failed > 0:
-        logger.warning("Done - Warning {} keys failed to be written ({} succeeded)"
-                       .format(keys_failed, keys_written))
+        logger.warning("Done - Warning %d keys failed to be written (%d succeeded)",
+                       keys_failed, keys_written)
     else:
-        logger.info("Done - {} keys written".format(keys_written))
+        logger.info("Done - %d keys written", keys_written)

--- a/katsdptelstate/rdb_writer.py
+++ b/katsdptelstate/rdb_writer.py
@@ -35,7 +35,7 @@ RDB_CHECKSUM = b'\x00\x00\x00\x00\x00\x00\x00\x00'
 logger = logging.getLogger(__name__)
 
 
-def encode_item(key, key_dump):
+def encode_item(key, dumped_value):
     """Encode key and corresponding DUMPed value to RDB format.
 
     First byte is used to indicate the encoding used for the value of this key.
@@ -61,9 +61,9 @@ def encode_item(key, key_dump):
     # the encoded value itself (including length specifier),
     # a trailing version specifier (2 bytes) and finally an 8 byte checksum.
     # The version specified and checksum are discarded.
-    key_type = key_dump[:1]
-    encoded_val = key_dump[1:-10]
-    return key_type + key_len + key + encoded_val
+    key_type = dumped_value[:1]
+    encoded_value = dumped_value[1:-10]
+    return key_type + key_len + key + encoded_value
 
 
 @contextmanager
@@ -135,11 +135,11 @@ class RDBWriter(object):
             keys = client.keys(b'*')
         for key in keys:
             key = _ensure_binary(key)
-            key_dump = client.dump(key)
+            dumped_value = client.dump(key)
             try:
-                if not key_dump:
+                if not dumped_value:
                     raise KeyError('Key not found in Redis')
-                encoded_str = encode_item(key, key_dump)
+                encoded_str = encode_item(key, dumped_value)
             except (ValueError, KeyError) as e:
                 self.keys_failed += 1
                 logger.error("Failed to save key %s: %s", _display_str(key), e)

--- a/katsdptelstate/test/test_rdb_handling.py
+++ b/katsdptelstate/test/test_rdb_handling.py
@@ -61,8 +61,10 @@ class TestRDBHandling(unittest.TestCase):
             rdbw.save(local_tr)
         self.assertEqual(rdbw.keys_written, 3)
         self.assertEqual(rdbw.keys_failed, 0)
-        with RDBWriter(self.base('one.rdb')) as rdbw:
-            rdbw.save(self.tr, keys=['writezl'])
+        # Also test that RDBWriter can work without a with-statement
+        rdbw = RDBWriter(self.base('one.rdb'))
+        rdbw.save(self.tr, keys=['writezl'])
+        rdbw.close()
         self.assertEqual(rdbw.keys_written, 1)
         self.assertEqual(rdbw.keys_failed, 0)
         with RDBWriter(self.base('broken.rdb')) as rdbw:

--- a/katsdptelstate/test/test_rdb_handling.py
+++ b/katsdptelstate/test/test_rdb_handling.py
@@ -133,7 +133,7 @@ class TestLoadFromFile(unittest.TestCase):
         write_ts.add('mutable', 'second', 15.5)
         # Write data to file
         with RDBWriter(file) as rdbw:
-            rdbw.save(write_ts.backend)
+            rdbw.save(write_ts)
 
     def load_from_file_and_check(self, file):
         # Load RDB file back into some backend

--- a/katsdptelstate/test/test_rdb_handling.py
+++ b/katsdptelstate/test/test_rdb_handling.py
@@ -39,7 +39,6 @@ class TestRDBHandling(unittest.TestCase):
     def setUp(self):
         # an empty tabloid redis instance
         self.tr = TabloidRedis()
-        self.rdb_writer = RDBWriter(client=self.tr)
         self.base_dir = tempfile.mkdtemp()
         self.addCleanup(shutil.rmtree, self.base_dir)
 
@@ -54,14 +53,28 @@ class TestRDBHandling(unittest.TestCase):
         self._add_test_vec('writezl')
         test_str = b"some string\x00\xa3\x17\x43and now valid\xff"
         self.tr.set('write', test_str)
-        self.assertEqual(self.rdb_writer.save(self.base('all.rdb'))[0], 2)
-        self.assertEqual(self.rdb_writer.save(self.base('one.rdb'), keys=['writezl'])[0], 1)
-        self.assertEqual(self.rdb_writer.save(self.base('broken.rdb'), keys=['does_not_exist'])[0], 0)
+        local_tr = TabloidRedis()
+        local_tr.set('extra', test_str)
+
+        with RDBWriter(self.base('all.rdb')) as rdbw:
+            rdbw.save(self.tr)
+            rdbw.save(local_tr)
+        self.assertEqual(rdbw.keys_written, 3)
+        self.assertEqual(rdbw.keys_failed, 0)
+        with RDBWriter(self.base('one.rdb')) as rdbw:
+            rdbw.save(self.tr, keys=['writezl'])
+        self.assertEqual(rdbw.keys_written, 1)
+        self.assertEqual(rdbw.keys_failed, 0)
+        with RDBWriter(self.base('broken.rdb')) as rdbw:
+            rdbw.save(self.tr, keys=['does_not_exist'])
+        self.assertEqual(rdbw.keys_written, 0)
+        self.assertEqual(rdbw.keys_failed, 1)
 
         local_tr = TabloidRedis()
-        self.assertEqual(load_from_file(RedisCallback(local_tr), self.base('all.rdb')), 2)
-        self.assertEqual(set(local_tr.keys()), {b'write', b'writezl'})
+        self.assertEqual(load_from_file(RedisCallback(local_tr), self.base('all.rdb')), 3)
+        self.assertEqual(set(local_tr.keys()), {b'write', b'writezl', b'extra'})
         self.assertEqual(local_tr.get('write'), test_str)
+        self.assertEqual(local_tr.get('extra'), test_str)
         vec = local_tr.zrange('writezl', 0, -1, withscores=True)
         self.assertEqual(vec, [(b'first', 0.0), (b'second', 0.0), (b'third\n\0', 0.0)])
 
@@ -73,7 +86,8 @@ class TestRDBHandling(unittest.TestCase):
 
     def _test_zset(self, items):
         zadd(self.tr, 'my_zset', {x: 0.0 for x in items})
-        self.rdb_writer.save(self.base('zset.rdb'))
+        with RDBWriter(self.base('zset.rdb')) as rdbw:
+            rdbw.save(self.tr)
 
         local_tr = TabloidRedis()
         load_from_file(RedisCallback(local_tr), self.base('zset.rdb'))
@@ -116,8 +130,8 @@ class TestLoadFromFile(unittest.TestCase):
         write_ts.add('mutable', 'first', 12.0)
         write_ts.add('mutable', 'second', 15.5)
         # Write data to file
-        rdb_writer = RDBWriter(client=write_ts.backend)
-        rdb_writer.save(file)
+        with RDBWriter(file) as rdbw:
+            rdbw.save(write_ts.backend)
 
     def load_from_file_and_check(self, file):
         # Load RDB file back into some backend


### PR DESCRIPTION
The main aim is to ensure that the RDB writer is not confused about keys being bytes or strings. It operates at the backend / Redis client level (which only knows bytes) but the user may specify keys as either strings or bytes (more likely the former). Use the recently added helper functions from #73 to manage the conversions and also update the docstrings to reflect reality.

The secondary aim is to clear up the treatment of supplemental keys, which are handled quite differently to the usual keys. Clear up the clutter of one-line helper methods and recast the RDBWriter as a file resource around the RDB file, allowing multiple calls to `save` with different Redis clients while still properly closing the file.

Simply put, instead of
```Python
rdbw = RDBWriter(client=telstate.backend)
supplemental_dumps = rdbw.encode_supplemental_keys(telstate2.backend, telstate2.keys())
keys_written, keys_failed = rdbw.save(dump_filename, keys=keys, supplemental_dumps=supplemental_dumps)
print(keys_written, keys_failed)
```
rather do
```Python
with RDBWriter(dump_filename) as rdbw:
    rdbw.save(telstate, keys)
    rdbw.save(telstate2)
print(rdbw.keys_written, rdbw.keys_failed)
```
or
```Python
rdbw = RDBWriter(dump_filename)
rdbw.save(telstate, keys)
rdbw.save(telstate2)
rdbw.close()
print(rdbw.keys_written, rdbw.keys_failed)
```
This requires updates to katsdpmetawriter's `meta_writer.py` and katdal's `mvf_rechunk.py` scripts as well.