### PR TITLE
Rip out get_message and send_message

### DIFF
--- a/katsdptelstate/memory.py
+++ b/katsdptelstate/memory.py
@@ -131,8 +131,8 @@ class MemoryBackend(Backend):
     It is optimised for read-only use, loading data from a .rdb file.
     Write operations are supported only to facilitate testing, but are not
     intended for production use. For that, use a :class:`.RedisBackend`
-    with an in-memory Redis emulation. The :meth:`monitor_keys`,
-    :meth:`send_message` and :meth:`get_message` methods are not implemented.
+    with an in-memory Redis emulation. The :meth:`monitor_keys` method is not
+    implemented.
 
     Mutable keys are stored as sorted lists, and encode timestamps in-place
     using the same packing as :class:`.RedisBackend`.

--- a/katsdptelstate/redis.py
+++ b/katsdptelstate/redis.py
@@ -31,7 +31,6 @@ except ImportError as _rdb_reader_import_error:   # noqa: F841
 
 
 _INF = float('inf')
-_MESSAGE_CHANNEL = b'tm_info'
 
 
 class RedisCallback(BackendCallback):
@@ -80,7 +79,7 @@ class RedisBackend(Backend):
         try:
             # This is the first command to the server and therefore
             # the first test of its availability
-            self._ps.subscribe(_MESSAGE_CHANNEL)
+            self.client.ping()
         except (redis.TimeoutError, redis.ConnectionError) as e:
             # redis.TimeoutError: bad host
             # redis.ConnectionError: good host, bad port
@@ -152,15 +151,6 @@ class RedisBackend(Backend):
         if not ans and not self.client.exists(key):
             return None
         return ans
-
-    def send_message(self, data):
-        self.client.publish(_MESSAGE_CHANNEL, data)
-
-    def get_message(self):
-        msg = self._ps.get_message(_MESSAGE_CHANNEL)
-        if msg is not None:
-            msg = msg['data']
-        return msg
 
     def monitor_keys(self, keys):
         p = self.client.pubsub()

--- a/katsdptelstate/telescope_state.py
+++ b/katsdptelstate/telescope_state.py
@@ -478,14 +478,6 @@ class Backend(object):
         """
         raise NotImplementedError
 
-    def send_message(self, data):
-        """Same as :meth:`TelescopeState.send_message`"""
-        raise NotImplementedError
-
-    def get_message(self):
-        """Same as :meth:`TelescopeState.get_message`"""
-        raise NotImplementedError
-
     def dump(self, key):
         """Return a key in the same format as the Redis DUMP command, or None if not present"""
         raise NotImplementedError
@@ -747,14 +739,6 @@ class TelescopeState(object):
             if prefix + key in self._backend:
                 return True
         return False
-
-    def send_message(self, data):
-        """Broadcast a message to all telescope model users."""
-        self._backend.send_message(data)
-
-    def get_message(self):
-        """Get the oldest unread telescope model message."""
-        return self._backend.get_message()
 
     def is_immutable(self, key):
         """Check to see if the specified key is an immutable."""


### PR DESCRIPTION
They have never been used and were untested. Communication has been done
through keys and wait_key instead, which is more reliable as messages
are namespaced to a key and it is robust to disconnections.