### PR TITLE
Allow the separator to be changed

### DIFF
--- a/katsdptelstate/memory.py
+++ b/katsdptelstate/memory.py
@@ -20,7 +20,7 @@ import bisect
 import re
 import logging
 
-from .telescope_state import Backend, ImmutableKeyError
+from .telescope_state import TelescopeState, Backend, ImmutableKeyError
 from .rdb_utility import dump_string, dump_zset
 try:
     from . import rdb_reader
@@ -112,11 +112,13 @@ class MemoryCallback(BackendCallback):
 
     def set(self, key, value, expiry, info):
         self.data[key] = value
-        self.n_keys += 1
+        if not key.startswith(TelescopeState._INTERNAL_MARKER):
+            self.n_keys += 1
 
     def start_sorted_set(self, key, length, expiry, info):
         self.data[key] = []
-        self.n_keys += 1
+        if not key.startswith(TelescopeState._INTERNAL_MARKER):
+            self.n_keys += 1
 
     def zadd(self, key, score, member):
         self.data[key].append(member)

--- a/katsdptelstate/rdb_reader.py
+++ b/katsdptelstate/rdb_reader.py
@@ -36,6 +36,8 @@ class BackendCallback(RdbCallback):
         self.n_keys = 0
         # Flag that helps to disambiguate callback errors from parser errors
         self.client_busy = False
+        # _SEPARATOR_KEY loaded from the file, if any
+        self.separator = None
 
 
 def _parse_rdb_file(parser, callback, fd, filename=None):
@@ -61,8 +63,11 @@ def load_from_file(callback, file):
 
     Returns
     -------
-    int
+    n_keys : int
         Number of keys loaded into backend
+    separator : bytes
+        Value of :const:`TelescopeState._SEPARATOR_KEY` if present, or the
+        old default (``_``) if not.
 
     Raises
     ------
@@ -83,4 +88,4 @@ def load_from_file(callback, file):
     else:
         with fd:
             _parse_rdb_file(parser, callback, fd, file)
-    return callback.n_keys
+    return callback.n_keys, callback.separator

--- a/katsdptelstate/rdb_writer.py
+++ b/katsdptelstate/rdb_writer.py
@@ -144,13 +144,15 @@ class RDBWriter(object):
             separator = client.get(TelescopeState._SEPARATOR_KEY)
         if separator is not None:
             if self._separator is not None and self._separator != separator:
-                    raise RuntimeError('Mismatched separators: {} != {}'.format(
-                        _display_str(separator), _display_str(self._separator)))
+                raise RuntimeError('Mismatched separators: {} != {}'.format(
+                    _display_str(separator), _display_str(self._separator)))
             if TelescopeState._SEPARATOR_KEY not in keys:
                 keys.append(TelescopeState._SEPARATOR_KEY)
 
         for key in keys:
             key = _ensure_binary(key)
+            # If save is called more than once, each call would write the
+            # separator. Ensure it is written only the first time.
             if key == TelescopeState._SEPARATOR_KEY and self._separator is not None:
                 continue       # It was already written
             dumped_value = client.dump(key)
@@ -165,7 +167,7 @@ class RDBWriter(object):
             self._fileobj.write(encoded_str)
             if key == TelescopeState._SEPARATOR_KEY:
                 self._separator = separator
-            else:
+            if TelescopeState._INTERNAL_MARKER not in key:
                 self.keys_written += 1
 
 

--- a/katsdptelstate/redis.py
+++ b/katsdptelstate/redis.py
@@ -20,7 +20,7 @@ import contextlib
 
 import redis
 
-from .telescope_state import ConnectionError, ImmutableKeyError, Backend
+from .telescope_state import TelescopeState, ConnectionError, ImmutableKeyError, Backend
 from . import compat
 try:
     from . import rdb_reader
@@ -44,11 +44,13 @@ class RedisCallback(BackendCallback):
         self.client_busy = True
         self.client.set(key, value, expiry)
         self.client_busy = False
-        self.n_keys += 1
+        if not key.startswith(TelescopeState._INTERNAL_MARKER):
+            self.n_keys += 1
 
     def start_sorted_set(self, key, length, expiry, info):
         self._zset = {}
-        self.n_keys += 1
+        if not key.startswith(TelescopeState._INTERNAL_MARKER):
+            self.n_keys += 1
 
     def zadd(self, key, score, member):
         self._zset[member] = score

--- a/katsdptelstate/telescope_state.py
+++ b/katsdptelstate/telescope_state.py
@@ -834,7 +834,8 @@ class TelescopeState(object):
         """
         key = _ensure_binary(key)
         if self._INTERNAL_MARKER in key:
-            raise InvalidKeyError("Cannot delete reserved keys")
+            raise InvalidKeyError("Cannot delete reserved keys ({!r} contains {!r})"
+                                  .format(key, self._INTERNAL_MARKER))
         for prefix in self._prefixes:
             self._backend.delete(prefix + key)
 

--- a/katsdptelstate/test/test_telescope_state.py
+++ b/katsdptelstate/test/test_telescope_state.py
@@ -557,3 +557,9 @@ class TestTelescopeStateAltSeparator(unittest.TestCase):
     def test_separator(self):
         self.assertEqual(self.ts.SEPARATOR, '+')
         self.assertEqual(self.ts.SEPARATOR_BYTES, b'+')
+
+    def test_clear(self):
+        # Make sure clear doesn't wipe out the separator
+        self.ts.clear()
+        ts2 = TelescopeState(self.ts.backend)
+        self.assertEqual(ts2.SEPARATOR, '+')


### PR DESCRIPTION
When establishing a TelescopeState, it attempts to write a key
\xffseparator (the prefix is chosen to avoid conflict with any possible
UTF-8-encoded string). If it already existed, the existing value is used
as the separator instead. The default choice of separator is not changed
now.

Once this version is used everywhere, the separator can be changed
without worrying about conflicts, because all users of a single
telescope state will negotiate a single separator (whichever arrived
first). The only time it will go wrong is when merging databases in
RDBWriter, where two databases may have different separators.

Partly implements SR-1832.