### PR TITLE
Disable pickles by default

### DIFF
--- a/katsdptelstate/__init__.py
+++ b/katsdptelstate/__init__.py
@@ -17,7 +17,7 @@
 from .telescope_state import (TelescopeState, ConnectionError, InvalidKeyError,
                               ImmutableKeyError, TimeoutError, CancelledError,
                               DecodeError, EncodeError, RdbParseError,
-                              PICKLE_PROTOCOL, encode_value, decode_value,
+                              PICKLE_PROTOCOL, encode_value, decode_value, set_allow_pickle,
                               ALLOWED_ENCODINGS, ENCODING_DEFAULT,
                               ENCODING_PICKLE, ENCODING_MSGPACK)
 

--- a/katsdptelstate/telescope_state.py
+++ b/katsdptelstate/telescope_state.py
@@ -76,7 +76,7 @@ PICKLE_ERROR = ('The telescope state contains pickled values. This is a security
                 'MeerKAT data up to March 2019.')
 
 
-def set_allow_pickle(allow, warn):
+def set_allow_pickle(allow, warn=False):
     """Control whether pickles are allowed.
 
     This overrides the defaults which are determined from the environment.
@@ -105,7 +105,7 @@ def _init_allow_pickle():
         allow = False
     elif env is not None:
         warnings.warn('Unknown value {!r} for KATSDPTELSTATE_ALLOW_PICKLE'.format(env))
-    set_allow_pickle(allow, False)
+    set_allow_pickle(allow)
 
 
 _init_allow_pickle()

--- a/katsdptelstate/test/test_telescope_state.py
+++ b/katsdptelstate/test/test_telescope_state.py
@@ -498,7 +498,7 @@ class TestTelescopeState(unittest.TestCase):
     def test_undecodable_bytes_in_key(self):
         """Gracefully handle non-UTF-8 bytes in keys."""
         key_b = b'undecodable\xff'
-        self.ts.backend.set_immutable(key_b, b"S'hello'\np1\n.")
+        self.ts.backend.set_immutable(key_b, encode_value('hello'))
         key = [k for k in self.ts.keys() if k.startswith('undecodable')][0]
         self.assertEqual(self.ts.get(key), 'hello')
         self.assertEqual(self.ts.get(key_b), 'hello')


### PR DESCRIPTION
They can still be re-enabled by environment variable
(KATSDPTELSTATE_ALLOW_PICKLE=1) or code
(katsdptelstate.set_allow_pickle).

Closes SR-1366.