### PR TITLE
Use python2 branches of katsdpdockerbase/katsdpjenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,8 @@
 #!groovy
 
-@Library('katsdpjenkins') _
+@Library('katsdpjenkins@python2') _
 katsdp.killOldJobs()
-katsdp.setDependencies(['ska-sa/katsdpdockerbase/master'])
-katsdp.standardBuild(python3: true, push_external: true)
+katsdp.setDependencies(['ska-sa/katsdpdockerbase/python2'])
+katsdp.standardBuild(python3: true, push_external: true,
+                     katsdpdockerbase_ref: 'python2')
 katsdp.mail('sdpdev+katsdptelstate@ska.ac.za')


### PR DESCRIPTION
Since they are planned to migrate to Python3-only.