### PR TITLE
Add type annotations

### DIFF
--- a/katsdptelstate/__init__.py
+++ b/katsdptelstate/__init__.py
@@ -33,5 +33,5 @@ except ImportError:
     import time as _time
     __version__ = "0.0+unknown.{}".format(_time.strftime('%Y%m%d%H%M'))
 else:
-    __version__ = _katversion.get_version(__path__[0])
+    __version__ = _katversion.get_version(__path__[0])                  # type: ignore
 # END VERSION CHECK

--- a/katsdptelstate/endpoint.py
+++ b/katsdptelstate/endpoint.py
@@ -16,7 +16,7 @@
 
 import socket
 import struct
-from typing import List, Iterable, Iterator, Callable, Optional, Any
+from typing import List, Iterable, Iterator, Callable, Any
 
 import ipaddress
 import netifaces
@@ -175,10 +175,10 @@ def endpoints_to_str(endpoints: Iterable[Endpoint]) -> str:
         # ipaddress module requires unicode, so convert if not already
         host = endpoint.host.decode('utf-8') if isinstance(endpoint.host, bytes) else endpoint.host
         try:
-            ipv4.append(Endpoint(ipaddress.IPv4Address(endpoint.host), endpoint.port))
+            ipv4.append(Endpoint(ipaddress.IPv4Address(host), endpoint.port))
         except ipaddress.AddressValueError:
             try:
-                ipv6.append(Endpoint(ipaddress.IPv6Address(endpoint.host), endpoint.port))
+                ipv6.append(Endpoint(ipaddress.IPv6Address(host), endpoint.port))
             except ipaddress.AddressValueError:
                 other.append(endpoint)
     # We build a list of parts, each of which is either host:port, addr:port or

--- a/katsdptelstate/errors.py
+++ b/katsdptelstate/errors.py
@@ -14,6 +14,10 @@
 # limitations under the License.
 ################################################################################
 
+from typing import Optional
+
+from .utils import _PathType
+
 
 class TelstateError(RuntimeError):
     """Base class for errors from this package."""
@@ -26,10 +30,10 @@ class ConnectionError(TelstateError):
 class RdbParseError(TelstateError):
     """Error parsing RDB file."""
 
-    def __init__(self, filename=None):
+    def __init__(self, filename: Optional[_PathType] = None) -> None:
         self.filename = filename
 
-    def __str__(self):
+    def __str__(self) -> str:
         name = repr(self.filename) if self.filename else 'object'
         return 'Invalid RDB file {}'.format(name)
 

--- a/katsdptelstate/memory.py
+++ b/katsdptelstate/memory.py
@@ -17,8 +17,11 @@
 import bisect
 import re
 import logging
+from datetime import datetime
+from typing import Pattern, List, Tuple, Dict, BinaryIO, Union, Optional
 
 from . import utils
+from .utils import _PathType
 from .backend import Backend
 from .errors import ImmutableKeyError
 from .rdb_utility import dump_string, dump_zset, dump_hash
@@ -26,14 +29,15 @@ try:
     from . import rdb_reader
     from .rdb_reader import BackendCallback
 except ImportError as _rdb_reader_import_error:   # noqa: F841
-    rdb_reader = None
-    BackendCallback = object     # So that MemoryCallback can still be defined
+    rdb_reader = None            # type: ignore
+    BackendCallback = object     # type: ignore   # So that MemoryCallback can still be defined
 
 
 logger = logging.getLogger(__name__)
+_Value = Union[bytes, Dict[bytes, bytes], List[bytes]]
 
 
-def _compile_pattern(pattern):
+def _compile_pattern(pattern: bytes) -> Pattern[bytes]:
     """Compile a glob pattern (e.g. for keys) to a bytes regex.
 
     fnmatch.fnmatchcase doesn't work for this, because it uses different
@@ -46,12 +50,12 @@ def _compile_pattern(pattern):
 
     # It's easier to work with text than bytes, because indexing bytes
     # doesn't behave the same in Python 3. Latin-1 will round-trip safely.
-    pattern = pattern.decode('latin-1')
+    pattern_str = pattern.decode('latin-1')
     parts = ['^']
     i = 0
-    L = len(pattern)
+    L = len(pattern_str)
     while i < L:
-        c = pattern[i]
+        c = pattern_str[i]
         i += 1
         if c == '?':
             parts.append('.')
@@ -60,30 +64,30 @@ def _compile_pattern(pattern):
         elif c == '\\':
             if i == L:
                 i -= 1
-            parts.append(re.escape(pattern[i]))
+            parts.append(re.escape(pattern_str[i]))
             i += 1
         elif c == '[':
             parts.append('[')
-            if i < L and pattern[i] == '^':
+            if i < L and pattern_str[i] == '^':
                 i += 1
                 parts.append('^')
             parts_len = len(parts)  # To detect if anything was added
             while i < L:
-                if pattern[i] == '\\' and i + 1 < L:
+                if pattern_str[i] == '\\' and i + 1 < L:
                     i += 1
-                    parts.append(re.escape(pattern[i]))
-                elif pattern[i] == ']':
+                    parts.append(re.escape(pattern_str[i]))
+                elif pattern_str[i] == ']':
                     i += 1
                     break
-                elif i + 2 < L and pattern[i + 1] == '-':
-                    start = pattern[i]
-                    end = pattern[i + 2]
+                elif i + 2 < L and pattern_str[i + 1] == '-':
+                    start = pattern_str[i]
+                    end = pattern_str[i + 2]
                     if start > end:
                         start, end = end, start
                     parts.append(re.escape(start) + '-' + re.escape(end))
                     i += 2
                 else:
-                    parts.append(re.escape(pattern[i]))
+                    parts.append(re.escape(pattern_str[i]))
                 i += 1
             if len(parts) == parts_len:
                 if parts[-1] == '[':
@@ -105,30 +109,32 @@ def _compile_pattern(pattern):
 
 class MemoryCallback(BackendCallback):
     """RDB callback that stores keys in :class:`MemoryBackend` data structure."""
-    def __init__(self, data):
+
+    def __init__(self, data: Dict[bytes, _Value]) -> None:
         super().__init__()
         self.data = data
 
-    def set(self, key, value, expiry, info):
+    def set(self, key: bytes, value: bytes, expiry: Optional[datetime], info: dict) -> None:
         self.data[key] = value
         self.n_keys += 1
 
-    def start_sorted_set(self, key, length, expiry, info):
+    def start_sorted_set(self, key: bytes, length: int,
+                         expiry: Optional[datetime], info: dict) -> None:
         self.data[key] = []
         self.n_keys += 1
 
-    def zadd(self, key, score, member):
-        self.data[key].append(member)
+    def zadd(self, key: bytes, score: float, member: bytes) -> None:
+        self.data[key].append(member)       # type: ignore
 
-    def end_sorted_set(self, key):
-        self.data[key].sort()
+    def end_sorted_set(self, key: bytes) -> None:
+        self.data[key].sort()               # type: ignore
 
-    def start_hash(self, key, length, expiry, info):
+    def start_hash(self, key: bytes, length: int, expiry: Optional[datetime], info: dict) -> None:
         self.data[key] = {}
         self.n_keys += 1
 
-    def hset(self, key, field, value):
-        self.data[key][field] = value
+    def hset(self, key: bytes, field: bytes, value: bytes) -> None:
+        self.data[key][field] = value       # type: ignore
 
 
 class MemoryBackend(Backend):
@@ -143,31 +149,31 @@ class MemoryBackend(Backend):
     Mutable keys are stored as sorted lists, and encode timestamps in-place
     using the same packing as :class:`.RedisBackend`.
     """
-    def __init__(self):
-        self._data = {}
+    def __init__(self) -> None:
+        self._data = {}       # type: Dict[bytes, _Value]
 
-    def load_from_file(self, file):
+    def load_from_file(self, file: Union[_PathType, BinaryIO]) -> int:
         if rdb_reader is None:
             raise _rdb_reader_import_error   # noqa: F821
         return rdb_reader.load_from_file(MemoryCallback(self._data), file)
 
-    def __contains__(self, key):
+    def __contains__(self, key: bytes) -> bool:
         return key in self._data
 
-    def keys(self, filter):
+    def keys(self, filter: bytes) -> List[bytes]:
         if filter == b'*':
             return list(self._data.keys())
         else:
             regex = _compile_pattern(filter)
             return [key for key in self._data.keys() if regex.match(key)]
 
-    def delete(self, key):
+    def delete(self, key: bytes) -> None:
         self._data.pop(key, None)
 
-    def clear(self):
+    def clear(self) -> None:
         self._data.clear()
 
-    def key_type(self, key):
+    def key_type(self, key: bytes) -> Optional[utils.KeyType]:
         value = self._data.get(key)
         if value is None:
             return None
@@ -180,7 +186,7 @@ class MemoryBackend(Backend):
         else:
             assert False
 
-    def set_immutable(self, key, value):
+    def set_immutable(self, key: bytes, value: bytes) -> Optional[bytes]:
         old = self._data.get(key)
         if old is None:
             self._data[key] = value
@@ -190,14 +196,19 @@ class MemoryBackend(Backend):
         else:
             raise ImmutableKeyError
 
-    def get(self, key):
+    def get(self, key: bytes) -> Union[
+            Tuple[None, None],
+            Tuple[bytes, None],
+            Tuple[bytes, float],
+            Tuple[Dict[bytes, bytes], None]]:
         value = self._data.get(key)
         if isinstance(value, list):
             return utils.split_timestamp(value[-1])
         else:
-            return value, None
+            # mypy is not smart enough to figure out that this is compatible
+            return value, None     # type: ignore
 
-    def add_mutable(self, key, value, timestamp):
+    def add_mutable(self, key: bytes, value: bytes, timestamp: float) -> None:
         str_val = utils.pack_timestamp(timestamp) + value
         items = self._data.get(key)
         if items is None:
@@ -211,7 +222,7 @@ class MemoryBackend(Backend):
         else:
             raise ImmutableKeyError
 
-    def set_indexed(self, key, sub_key, value):
+    def set_indexed(self, key: bytes, sub_key: bytes, value: bytes) -> Optional[bytes]:
         item = self._data.setdefault(key, {})
         if not isinstance(item, dict):
             raise ImmutableKeyError
@@ -221,14 +232,15 @@ class MemoryBackend(Backend):
             item[sub_key] = value
             return None
 
-    def get_indexed(self, key, sub_key):
+    def get_indexed(self, key: bytes, sub_key: bytes) -> Optional[bytes]:
         item = self._data[key]
         if not isinstance(item, dict):
             raise ImmutableKeyError
         return item.get(sub_key)
 
     @classmethod
-    def _bisect(cls, items, timestamp, is_end, include_end=False):
+    def _bisect(cls, items: List[bytes], timestamp: float,
+                is_end: bool, include_end: bool = False) -> int:
         packed = utils.pack_query_timestamp(timestamp, is_end, include_end)
         if packed == b'-':
             return 0
@@ -238,11 +250,12 @@ class MemoryBackend(Backend):
             # pack_query_timestamp adds a prefix of [ or (, which we don't need
             return bisect.bisect_left(items, packed[1:])
 
-    def get_range(self, key, start_time, end_time, include_previous, include_end):
+    def get_range(self, key: bytes, start_time: float, end_time: float,
+                  include_previous: bool, include_end: bool) -> Optional[List[Tuple[bytes, float]]]:
         items = self._data.get(key)
         if items is None:
             return None
-        elif isinstance(items, bytes):
+        elif not isinstance(items, list):
             raise ImmutableKeyError
 
         start_pos = self._bisect(items, start_time, False)
@@ -251,7 +264,7 @@ class MemoryBackend(Backend):
         end_pos = self._bisect(items, end_time, True, include_end)
         return [utils.split_timestamp(value) for value in items[start_pos:end_pos]]
 
-    def dump(self, key):
+    def dump(self, key: bytes) -> Optional[bytes]:
         value = self._data.get(key)
         if value is None:
             return None

--- a/katsdptelstate/rdb_utility.py
+++ b/katsdptelstate/rdb_utility.py
@@ -22,13 +22,14 @@ https://github.com/sripathikrishnan/redis-rdb-tools/wiki/Redis-RDB-Dump-File-For
 
 import struct
 import itertools
+from typing import Mapping, Sequence, Iterable, Union
 
 
 # Version 6 (first two bytes), and a zero checksum
 DUMP_POSTFIX = b"\x06\x00\x00\x00\x00\x00\x00\x00\x00\x00"
 
 
-def encode_len(length):
+def encode_len(length: int) -> bytes:
     """Encodes the specified length as 1,2 or 5 bytes of
     RDB specific length encoded byte.
 
@@ -50,7 +51,7 @@ def encode_len(length):
     return struct.pack('>Q', 0x8000000000 + length)[3:]
 
 
-def encode_prev_length(length):
+def encode_prev_length(length: int) -> bytes:
     """Special helper for zset previous entry lengths.
 
     If length < 253 then use 1 byte directly, otherwise
@@ -62,14 +63,14 @@ def encode_prev_length(length):
     return b'\xfe' + struct.pack("<I", length)
 
 
-def dump_string(data):
+def dump_string(data: bytes) -> bytes:
     """Encode a binary string as per redis DUMP command"""
     type_specifier = b'\x00'
     encoded_length = encode_len(len(data))
     return type_specifier + encoded_length + data + DUMP_POSTFIX
 
 
-def encode_ziplist(entries):
+def encode_ziplist(entries: Iterable[Union[bytes, int]]) -> bytes:
     """Create an RDB ziplist, including the envelope.
 
     The entries can either be byte strings or integers, and any iterable can
@@ -120,7 +121,7 @@ def encode_ziplist(entries):
     return b''.join(raw_entries)
 
 
-def dump_iterable(prefix, suffix, entries):
+def dump_iterable(prefix: bytes, suffix: bytes, entries: Iterable[bytes]) -> bytes:
     """Output a sequence of strings, bracketed by a prefix and suffix.
 
     This is an internal function used to implement :func:`dump_zset` and
@@ -133,7 +134,7 @@ def dump_iterable(prefix, suffix, entries):
     return b''.join(enc)
 
 
-def dump_zset(data):
+def dump_zset(data: Sequence[bytes]) -> bytes:
     """Encode a set of values as a redis zset, as per redis DUMP command.
 
     All scores are assumed to be zero and encoded in the most efficient way
@@ -170,7 +171,7 @@ def dump_zset(data):
         return b'\x0c' + encode_len(len(zl_envelope)) + zl_envelope + DUMP_POSTFIX
 
 
-def dump_hash(data):
+def dump_hash(data: Mapping[bytes, bytes]) -> bytes:
     """Encode a dictionary as a redis hash, as per redis DUMP command.
 
     The encoding is similar to zsets, but using the value instead of the score.

--- a/katsdptelstate/redis.py
+++ b/katsdptelstate/redis.py
@@ -120,7 +120,7 @@ class RedisBackend(Backend):
             # redis.TimeoutError: bad host
             # redis.ConnectionError: good host, bad port
             raise ConnectionError("could not connect to redis server: {}".format(e))
-        self._scripts = {}     # type: Dict[str, redis.Script]
+        self._scripts = {}     # type: Dict[str, redis.client.Script]
         for script_name in ['get', 'set_immutable', 'get_indexed', 'set_indexed',
                             'add_mutable', 'get_range']:
             script = pkg_resources.resource_string(

--- a/katsdptelstate/redis.py
+++ b/katsdptelstate/redis.py
@@ -44,7 +44,8 @@ class RedisCallback(BackendCallback):
 
     def set(self, key: bytes, value: bytes, expiry: Optional[datetime], info: dict) -> None:
         self.client_busy = True
-        self.client.set(key, value)
+        # mypy 0.720's typeshed doesn't allow bytes keys
+        self.client.set(key, value)        # type: ignore
         if expiry is not None:
             self.client.expireat(key, expiry)
         self.client_busy = False
@@ -119,7 +120,7 @@ class RedisBackend(Backend):
             # redis.TimeoutError: bad host
             # redis.ConnectionError: good host, bad port
             raise ConnectionError("could not connect to redis server: {}".format(e))
-        self._scripts = {}
+        self._scripts = {}     # type: Dict[str, redis.Script]
         for script_name in ['get', 'set_immutable', 'get_indexed', 'set_indexed',
                             'add_mutable', 'get_range']:
             script = pkg_resources.resource_string(

--- a/katsdptelstate/test/test_endpoint.py
+++ b/katsdptelstate/test/test_endpoint.py
@@ -23,45 +23,45 @@ from katsdptelstate.endpoint import (
 
 
 class TestEndpoint:
-    def test_str(self):
+    def test_str(self) -> None:
         assert_equal('test.me:80', str(Endpoint('test.me', 80)))
         assert_equal('[1080::8:800:200C:417A]:12345', str(Endpoint('1080::8:800:200C:417A', 12345)))
 
-    def test_repr(self):
+    def test_repr(self) -> None:
         assert_equal("Endpoint('test.me', 80)", repr(Endpoint('test.me', 80)))
 
-    def test_parser_default_port(self):
+    def test_parser_default_port(self) -> None:
         parser = endpoint_parser(1234)
         assert_equal(Endpoint('hello', 1234), parser('hello'))
         assert_equal(Endpoint('192.168.0.1', 1234), parser('192.168.0.1'))
         assert_equal(Endpoint('1080::8:800:200C:417A', 1234), parser('[1080::8:800:200C:417A]'))
 
-    def test_parser_port(self):
+    def test_parser_port(self) -> None:
         parser = endpoint_parser(1234)
         assert_equal(Endpoint('hello', 80), parser('hello:80'))
         assert_equal(Endpoint('1080::8:800:200C:417A', 80), parser('[1080::8:800:200C:417A]:80'))
 
-    def test_bad_ipv6(self):
+    def test_bad_ipv6(self) -> None:
         parser = endpoint_parser(1234)
         assert_raises(ValueError, parser, '[notipv6]:1234')
 
-    def test_iter(self):
+    def test_iter(self) -> None:
         endpoint = Endpoint('hello', 80)
         assert_equal(('hello', 80), tuple(endpoint))
 
-    def test_eq(self):
+    def test_eq(self) -> None:
         assert_equal(Endpoint('hello', 80), Endpoint('hello', 80))
         assert_not_equal(Endpoint('hello', 80), Endpoint('hello', 90))
         assert_not_equal(Endpoint('hello', 80), Endpoint('world', 80))
         assert_not_equal(Endpoint('hello', 80), 'not_an_endpoint')
 
-    def test_hash(self):
+    def test_hash(self) -> None:
         assert_equal(hash(Endpoint('hello', 80)), hash(Endpoint('hello', 80)))
         assert_not_equal(hash(Endpoint('hello', 80)), hash(Endpoint('hello', 90)))
 
 
 class TestEndpointList:
-    def test_parser(self):
+    def test_parser(self) -> None:
         parser = endpoint_list_parser(1234)
         endpoints = parser(
             'hello:80,world,[1080::8:800:200C:417A],192.168.0.255+4,10.0.255.255+3:60')
@@ -81,26 +81,26 @@ class TestEndpointList:
         ]
         assert_equal(expected, endpoints)
 
-    def test_parser_bad_count(self):
+    def test_parser_bad_count(self) -> None:
         assert_raises(ValueError, endpoint_list_parser(1234), '192.168.0.1+-4')
 
-    def test_parser_non_integer_count(self):
+    def test_parser_non_integer_count(self) -> None:
         assert_raises(ValueError, endpoint_list_parser(1234), '192.168.0.1+hello')
 
-    def test_parser_count_without_ipv4(self):
+    def test_parser_count_without_ipv4(self) -> None:
         assert_raises(ValueError, endpoint_list_parser(1234), 'hello.world+4')
 
-    def test_parser_single_port(self):
+    def test_parser_single_port(self) -> None:
         parser = endpoint_list_parser(1234, single_port=True)
         endpoints = parser('hello:1234,world')
         expected = [Endpoint('hello', 1234), Endpoint('world', 1234)]
         assert_equal(expected, endpoints)
 
-    def test_parser_single_port_bad(self):
+    def test_parser_single_port_bad(self) -> None:
         assert_raises(ValueError, endpoint_list_parser(1234, single_port=True), 'x:123,y:456')
 
 
-def test_endpoints_to_str():
+def test_endpoints_to_str() -> None:
     endpoints = [
         Endpoint('hostname', 1234),
         Endpoint('1.2.3.4', 7148),

--- a/katsdptelstate/test/test_telescope_state.py
+++ b/katsdptelstate/test/test_telescope_state.py
@@ -31,14 +31,14 @@ from katsdptelstate.memory import MemoryBackend
 
 
 class TestTelescopeState(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         self.ts = self.make_telescope_state()
         self.ns = self.ts.view('ns')
 
-    def make_telescope_state(self):
+    def make_telescope_state(self) -> TelescopeState:
         return TelescopeState()
 
-    def test_bad_construct(self):
+    def test_bad_construct(self) -> None:
         with self.assertRaises(ValueError):
             TelescopeState('redis.example.com:7148', base=self.ts)
         with self.assertRaises(ValueError):
@@ -48,7 +48,7 @@ class TestTelescopeState(unittest.TestCase):
         with self.assertRaises(ValueError):
             TelescopeState(db=1)
 
-    def test_namespace(self):
+    def test_namespace(self) -> None:
         self.assertEqual(self.ts.prefixes, ('',))
         self.assertEqual(self.ns.prefixes, ('ns_', ''))
         ns2 = self.ns.view(b'ns_child_grandchild')
@@ -57,7 +57,7 @@ class TestTelescopeState(unittest.TestCase):
         ns_excl = self.ns.view('exclusive', exclusive=True)
         self.assertEqual(ns_excl.prefixes, ('exclusive_',))
 
-    def test_basic_add(self):
+    def test_basic_add(self) -> None:
         self.ts.add('test_key', 1234.5)
         self.assertEqual(self.ts.test_key, 1234.5)
         self.assertEqual(self.ts['test_key'], 1234.5)
@@ -66,7 +66,7 @@ class TestTelescopeState(unittest.TestCase):
         with self.assertRaises(AttributeError):
             self.ts.test_key
 
-    def test_namespace_add(self):
+    def test_namespace_add(self) -> None:
         self.ns.add('test_key', 1234.5)
         self.assertEqual(self.ns.test_key, 1234.5)
         self.assertEqual(self.ns['test_key'], 1234.5)
@@ -74,7 +74,7 @@ class TestTelescopeState(unittest.TestCase):
         with self.assertRaises(KeyError):
             self.ts['test_key']
 
-    def test_method_protection(self):
+    def test_method_protection(self) -> None:
         with self.assertRaises(InvalidKeyError):
             self.ts.add('get', 1234.5)
         with self.assertRaises(InvalidKeyError):
@@ -82,31 +82,31 @@ class TestTelescopeState(unittest.TestCase):
         with self.assertRaises(InvalidKeyError):
             self.ts.set_indexed('get', 'sub', 1)
 
-    def test_delete(self):
+    def test_delete(self) -> None:
         self.ts.add('test_key', 1234.5)
         self.assertIn('test_key', self.ts)
         self.ts.delete('test_key')
         self.ts.delete('test_key')
         self.assertNotIn('test_key', self.ts)
 
-    def test_namespace_delete(self):
+    def test_namespace_delete(self) -> None:
         self.ts.add('parent_key', 1234.5)
         self.ns.add('child_key', 2345.6)
         self.ns.delete('child_key')
         self.ns.delete('parent_key')
         self.assertEqual(self.ts.keys(), [])
 
-    def test_clear(self):
+    def test_clear(self) -> None:
         self.ts.add('test_key', 1234.5)
         self.ts.add('test_key_rt', 2345.6)
         self.ts.clear()
         self.assertEqual(self.ts.keys(), [])
 
-    def test_get_default(self):
+    def test_get_default(self) -> None:
         self.assertIsNone(self.ts.get('foo'))
         self.assertEqual(self.ts.get('foo', 'bar'), 'bar')
 
-    def test_get_return_encoded(self):
+    def test_get_return_encoded(self) -> None:
         for immutable in [True, False]:
             x = np.array([(1.0, 2), (3.0, 4)], dtype=[('x', float), ('y', int)])
             self.ts.add('test_key_rt', x, immutable=True)
@@ -116,7 +116,7 @@ class TestTelescopeState(unittest.TestCase):
             self.assertEqual(x_encoded, encode_value(x))
             self.ts.delete('test_key_rt')
 
-    def test_get_range_return_encoded(self):
+    def test_get_range_return_encoded(self) -> None:
         test_values = ['Test Value: {}'.format(x) for x in range(5)]
         for i, test_value in enumerate(test_values):
             self.ts.add('test_key', test_value, i)
@@ -127,7 +127,7 @@ class TestTelescopeState(unittest.TestCase):
         # check timestamp
         self.assertEqual(stored_values_pickled[2][1], 2)
 
-    def test_immutable(self):
+    def test_immutable(self) -> None:
         self.ts.add('test_immutable', 1234.5, immutable=True)
         with self.assertRaises(ImmutableKeyError):
             self.ts.add('test_immutable', 1234.5)
@@ -136,7 +136,7 @@ class TestTelescopeState(unittest.TestCase):
         with self.assertRaises(ImmutableKeyError):
             self.ts.set_indexed('test_immutable', 1234.5, 1234.5)
 
-    def test_immutable_same_value(self):
+    def test_immutable_same_value(self) -> None:
         self.ts.add('test_immutable', 1234.5, immutable=True)
         self.ts.add('test_mutable', 1234.5)
         with self.assertRaises(ImmutableKeyError):
@@ -144,7 +144,7 @@ class TestTelescopeState(unittest.TestCase):
 
     @mock.patch('katsdptelstate.encoding._allow_pickle', True)
     @mock.patch('katsdptelstate.encoding._warn_on_pickle', False)
-    def test_immutable_same_value_str(self):
+    def test_immutable_same_value_str(self) -> None:
         self.ts.add('test_bytes', b'caf\xc3\xa9', immutable=True)
         self.ts.add('test_bytes', b'caf\xc3\xa9', immutable=True)
         self.ts.add('test_bytes', 'café', immutable=True)
@@ -173,14 +173,14 @@ class TestTelescopeState(unittest.TestCase):
         with self.assertRaisesRegex(ImmutableKeyError, 'failed to decode the previous value'):
             self.ts.add('test_failed_decode', '', immutable=True)
 
-    def test_immutable_none(self):
+    def test_immutable_none(self) -> None:
         self.ts.add('test_none', None, immutable=True)
         self.assertIsNone(self.ts.get('test_none'))
         self.assertIsNone(self.ts.get('test_none', 'not_none'))
         self.assertIsNone(self.ts.test_none)
         self.assertIsNone(self.ts['test_none'])
 
-    def test_immutable_wrong_type(self):
+    def test_immutable_wrong_type(self) -> None:
         self.ts.add('test_mutable', 5)
         self.ts.add('test_indexed', 5, 5)
         with self.assertRaises(ImmutableKeyError):
@@ -188,7 +188,7 @@ class TestTelescopeState(unittest.TestCase):
         with self.assertRaises(ImmutableKeyError):
             self.ts.add('test_indexed', 5, immutable=True)
 
-    def test_namespace_immutable(self):
+    def test_namespace_immutable(self) -> None:
         self.ts.add('parent_immutable', 1234.5, immutable=True)
         self.ns.add('child_immutable', 2345.5, immutable=True)
         with self.assertRaises(KeyError):
@@ -196,7 +196,7 @@ class TestTelescopeState(unittest.TestCase):
         self.assertEqual(self.ns.get('child_immutable'), 2345.5)
         self.assertEqual(self.ns.get('parent_immutable'), 1234.5)
 
-    def test_key_type(self):
+    def test_key_type(self) -> None:
         self.ts.add('parent_immutable', 1, immutable=True)
         self.ns.add('child_immutable', 2, immutable=True)
         self.ts.add('parent', 3)
@@ -219,7 +219,7 @@ class TestTelescopeState(unittest.TestCase):
         self.assertEqual(self.ns.key_type('child_indexed'), KeyType.INDEXED)
         self.assertEqual(self.ns.key_type('not_a_key'), None)
 
-    def test_keys(self):
+    def test_keys(self) -> None:
         self.ts.add('key1', 'a')
         self.ns.add('key2', 'b')
         self.ns.add(b'key2', 'c')
@@ -227,31 +227,31 @@ class TestTelescopeState(unittest.TestCase):
         self.assertEqual(self.ts.keys(), ['immutable', 'key1', 'ns_key2'])
         self.assertEqual(self.ts.keys('ns_*'), ['ns_key2'])
 
-    def test_complex_store(self):
+    def test_complex_store(self) -> None:
         x = np.array([(1.0, 2), (3.0, 4)], dtype=[('x', float), ('y', int)])
         self.ts.add('test_key', x)
         self.assertTrue((self.ts.test_key == x).all())
 
-    def test_contains(self):
+    def test_contains(self) -> None:
         self.ts.add('test_key', 1234.5)
         self.assertTrue('test_key' in self.ts)
         self.assertFalse('nonexistent_test_key' in self.ts)
 
-    def test_setattr(self):
+    def test_setattr(self) -> None:
         self.ts.test_key = 'foo'
         self.assertEqual(self.ts['test_key'], 'foo')
         self.assertEqual(self.ts.key_type('test_key'), KeyType.IMMUTABLE)
         with self.assertRaises(AttributeError):
-            self.ts.root = 'root is a method'
+            self.ts.root = 'root is a method'    # type: ignore
         self.ts._internal = 'bar'
         self.assertFalse('_internal' in self.ts)
 
-    def test_setitem(self):
+    def test_setitem(self) -> None:
         self.ts['test_key'] = 'foo'
         self.assertEqual(self.ts['test_key'], 'foo')
         self.assertEqual(self.ts.key_type('test_key'), KeyType.IMMUTABLE)
 
-    def test_time_range(self):
+    def test_time_range(self) -> None:
         self.ts.delete('test_key')
         self.ts.add('test_key', 8192, 1)
         self.ts.add('test_key', 16384, 2)
@@ -281,7 +281,7 @@ class TestTelescopeState(unittest.TestCase):
         self.assertRaises(KeyError, self.ts.get_range, 'not_a_key')
         self.assertRaises(ImmutableKeyError, self.ts.get_range, 'test_immutable')
 
-    def test_time_range_include_end(self):
+    def test_time_range_include_end(self) -> None:
         self.ts.add('test_key', 1234, 0)
         self.ts.add('test_key', 8192, 1)
         self.ts.add('test_key', 16384, 2)
@@ -301,28 +301,28 @@ class TestTelescopeState(unittest.TestCase):
                          self.ts.get_range('test_key', st=2, et=3,
                                            include_previous=True, include_end=True))
 
-    def test_add_duplicate(self):
+    def test_add_duplicate(self) -> None:
         self.ts.add('test_key', 'value', 1234.5)
         self.ts.add('test_key', 'value', 1234.5)
         self.assertEqual([('value', 1234.5)], self.ts.get_range('test_key', st=0))
 
-    def test_wait_key_already_done_mutable(self):
+    def test_wait_key_already_done_mutable(self) -> None:
         """Calling wait_key with a condition that is met must return (mutable version)."""
         self.ts.add('test_key', 123)
         value, timestamp = self.ts.get_range('test_key')[0]
         self.ts.wait_key('test_key', lambda v, t: v == value and t == timestamp)
 
-    def test_wait_key_already_done_immutable(self):
+    def test_wait_key_already_done_immutable(self) -> None:
         """Calling wait_key with a condition that is met must return (immutable version)."""
         self.ts.add('test_key', 123, immutable=True)
         self.ts.wait_key('test_key', lambda v, t: v == self.ts['test_key'] and t is None)
 
-    def test_wait_key_already_done_indexed(self):
+    def test_wait_key_already_done_indexed(self) -> None:
         """Calling wait_key with a condition that is met must return (indexed version)."""
         self.ts.set_indexed('test_key', 'idx', 5)
         self.ts.wait_key('test_key', lambda v, t: v == {'idx': 5} and t is None)
 
-    def test_wait_key_timeout(self):
+    def test_wait_key_timeout(self) -> None:
         """wait_key must time out in the given time if the condition is not met"""
         with self.assertRaises(TimeoutError):
             self.ts.wait_key('test_key', timeout=0.1)
@@ -330,19 +330,19 @@ class TestTelescopeState(unittest.TestCase):
             # Takes a different code path, even though equivalent
             self.ts.wait_key('test_key', lambda value, ts: True, timeout=0.1)
 
-    def _set_key_immutable(self):
+    def _set_key_immutable(self) -> None:
         time.sleep(0.1)
         self.ts['test_key'] = 123
 
-    def _set_key_mutable(self):
+    def _set_key_mutable(self) -> None:
         time.sleep(0.1)
         self.ts.add('test_key', 123, ts=1234567890)
 
-    def _set_key_indexed(self):
+    def _set_key_indexed(self) -> None:
         time.sleep(0.1)
         self.ts.set_indexed('test_key', 'idx', 123)
 
-    def test_wait_key_delayed(self):
+    def test_wait_key_delayed(self) -> None:
         """wait_key must succeed with a timeout that does not expire before the condition is met."""
         for (set_key, value, timestamp) in [
                 (self._set_key_mutable, 123, 1234567890),
@@ -355,7 +355,7 @@ class TestTelescopeState(unittest.TestCase):
             thread.join()
             self.ts.delete('test_key')
 
-    def test_wait_key_delayed_unconditional(self):
+    def test_wait_key_delayed_unconditional(self) -> None:
         """wait_key must succeed when given a timeout that does not expire before key appears."""
         for set_key, value in [
                 (self._set_key_mutable, 123),
@@ -368,21 +368,21 @@ class TestTelescopeState(unittest.TestCase):
             thread.join()
             self.ts.delete('test_key')
 
-    def test_wait_key_already_cancelled(self):
+    def test_wait_key_already_cancelled(self) -> None:
         """wait_key must raise :exc:`CancelledError` if the `cancel_future` is already done."""
         future = mock.MagicMock()
         future.done.return_value = True
         with self.assertRaises(CancelledError):
             self.ts.wait_key('test_key', cancel_future=future)
 
-    def test_wait_key_already_done_and_cancelled(self):
+    def test_wait_key_already_done_and_cancelled(self) -> None:
         """wait_key is successful if both the condition and the cancellation are done on entry."""
         future = mock.MagicMock()
         future.done.return_value = True
         self.ts.add('test_key', 123)
         self.ts.wait_key('test_key', lambda value, ts: value == 123, cancel_future=future)
 
-    def test_wait_key_cancel(self):
+    def test_wait_key_cancel(self) -> None:
         """wait_key must return when cancelled."""
         def cancel():
             time.sleep(0.1)
@@ -394,7 +394,7 @@ class TestTelescopeState(unittest.TestCase):
         with self.assertRaises(CancelledError):
             self.ts.wait_key('test_key', cancel_future=future)
 
-    def test_wait_key_shadow(self):
+    def test_wait_key_shadow(self) -> None:
         """updates to a shadowed qualified key must be ignored"""
         def set_key(telstate):
             time.sleep(0.1)
@@ -416,12 +416,12 @@ class TestTelescopeState(unittest.TestCase):
         ns2.wait_key('test_key', lambda value, ts: value is True, timeout=0.5)
         thread.join()
 
-    def test_wait_indexed_already_done(self):
+    def test_wait_indexed_already_done(self) -> None:
         self.ts.set_indexed('test_key', 'sub_key', 5)
         self.ts.wait_indexed('test_key', 'sub_key')
         self.ts.wait_indexed('test_key', 'sub_key', lambda v: v == 5)
 
-    def test_wait_indexed_timeout(self):
+    def test_wait_indexed_timeout(self) -> None:
         self.ts.set_indexed('test_key', 'sub_key', 5)
         with self.assertRaises(TimeoutError):
             self.ts.wait_indexed('test_key', 'sub_key', lambda v: v == 4, timeout=0.05)
@@ -430,7 +430,7 @@ class TestTelescopeState(unittest.TestCase):
         with self.assertRaises(TimeoutError):
             self.ts.wait_indexed('not_present', 'sub_key', timeout=0.05)
 
-    def test_wait_indexed_delayed(self):
+    def test_wait_indexed_delayed(self) -> None:
         def set_key():
             self.ts.set_indexed('test_key', 'foo', 1)
             time.sleep(0.05)
@@ -443,19 +443,19 @@ class TestTelescopeState(unittest.TestCase):
             self.assertEqual(2, self.ts.get_indexed('test_key', 'bar'))
             thread.join()
 
-    def test_wait_indexed_already_cancelled(self):
+    def test_wait_indexed_already_cancelled(self) -> None:
         future = mock.MagicMock()
         future.done.return_value = True
         with self.assertRaises(CancelledError):
             self.ts.wait_indexed('test_key', 'foo', cancel_future=future)
 
-    def test_wait_indexed_already_done_and_cancelled(self):
+    def test_wait_indexed_already_done_and_cancelled(self) -> None:
         future = mock.MagicMock()
         future.done.return_value = True
         self.ts.set_indexed('test_key', 'sub_key', 1)
         self.ts.wait_indexed('test_key', 'sub_key', lambda value: value == 1, cancel_future=future)
 
-    def test_wait_indexed_cancel(self):
+    def test_wait_indexed_cancel(self) -> None:
         def cancel():
             time.sleep(0.1)
             future.done.return_value = True
@@ -466,7 +466,7 @@ class TestTelescopeState(unittest.TestCase):
         with self.assertRaises(CancelledError):
             self.ts.wait_indexed('test_key', 'sub_key', cancel_future=future)
 
-    def test_wait_indexed_shadow(self):
+    def test_wait_indexed_shadow(self) -> None:
         def set_key(telstate):
             time.sleep(0.1)
             telstate.set_indexed('test_key', 'sub_key', 1)
@@ -478,7 +478,7 @@ class TestTelescopeState(unittest.TestCase):
         with self.assertRaises(TimeoutError):
             self.ns.wait_indexed('test_key', 'sub_key', timeout=0.2)
 
-    def test_wait_indexed_wrong_type(self):
+    def test_wait_indexed_wrong_type(self) -> None:
         def set_key():
             time.sleep(0.1)
             self.ts.add('test_key', 'value')
@@ -492,7 +492,7 @@ class TestTelescopeState(unittest.TestCase):
         with self.assertRaises(ImmutableKeyError):
             self.ts.wait_indexed('test_key', 'value')
 
-    def _test_mixed_unicode_bytes(self, ns, key):
+    def _test_mixed_unicode_bytes(self, ns, key) -> None:
         self.ts.clear()
         ns.add(key, 'value', immutable=True)
         self.assertEqual(ns.get(key), 'value')
@@ -504,11 +504,11 @@ class TestTelescopeState(unittest.TestCase):
             ns.get_range(key), [('value1', 1.0)])
         ns.wait_key(key)
 
-    def test_mixed_unicode_bytes(self):
+    def test_mixed_unicode_bytes(self) -> None:
         self._test_mixed_unicode_bytes(self.ts.view(b'ns'), 'test_key')
         self._test_mixed_unicode_bytes(self.ts.view('ns'), b'test_key')
 
-    def test_undecodable_bytes_in_key(self):
+    def test_undecodable_bytes_in_key(self) -> None:
         """Gracefully handle non-UTF-8 bytes in keys."""
         key_b = b'undecodable\xff'
         self.ts.backend.set_immutable(key_b, encode_value('hello'))
@@ -517,7 +517,7 @@ class TestTelescopeState(unittest.TestCase):
         self.assertEqual(self.ts.get(key_b), 'hello')
         self.assertEqual(self.ts.get(key_b[1:]), None)
 
-    def test_tab_completion(self):
+    def test_tab_completion(self) -> None:
         self.ts['z'] = 'value'
         self.ns['b'] = 'value'
         self.ns['a'] = 'value'
@@ -526,7 +526,7 @@ class TestTelescopeState(unittest.TestCase):
         keys = self.ts._ipython_key_completions_()
         self.assertEqual(sorted(keys), ['ns_a', 'ns_b', 'z'])
 
-    def test_get_indexed(self):
+    def test_get_indexed(self) -> None:
         self.ts.set_indexed('test_indexed', 'a', 1)
         self.ts.set_indexed('test_indexed', (2, 3j), 2)
         self.assertEqual(self.ts.get_indexed('test_indexed', 'a'), 1)
@@ -537,7 +537,7 @@ class TestTelescopeState(unittest.TestCase):
         self.assertEqual(self.ts.get_indexed('not_a_key', 'missing', 'default'), 'default')
         self.assertEqual(self.ts.get('test_indexed'), {'a': 1, (2, 3j): 2})
 
-    def test_indexed_return_encoded(self):
+    def test_indexed_return_encoded(self) -> None:
         self.ts.set_indexed('test_indexed', 'a', 1)
         values = self.ts.get('test_indexed', return_encoded=True)
         self.assertEqual(values, {
@@ -546,18 +546,18 @@ class TestTelescopeState(unittest.TestCase):
         self.assertEqual(self.ts.get_indexed('test_indexed', 'a', return_encoded=True),
                          encode_value(1))
 
-    def test_set_indexed_immutable(self):
+    def test_set_indexed_immutable(self) -> None:
         self.ts.set_indexed('test_indexed', 'a', 1)
         self.ts.set_indexed('test_indexed', 'a', 1)  # Same value is okay
         with self.assertRaises(ImmutableKeyError):
             self.ts.set_indexed('test_indexed', 'a', 2)
         self.assertEqual(self.ts.get_indexed('test_indexed', 'a'), 1)
 
-    def test_set_indexed_unhashable(self):
+    def test_set_indexed_unhashable(self) -> None:
         with self.assertRaises(TypeError):
             self.ts.set_indexed('test_indexed', ['list', 'is', 'not', 'hashable'], 0)
 
-    def test_indexed_wrong_type(self):
+    def test_indexed_wrong_type(self) -> None:
         self.ts['test_immutable'] = 1
         self.ts.add('test_mutable', 2)
         with self.assertRaises(ImmutableKeyError):
@@ -569,7 +569,7 @@ class TestTelescopeState(unittest.TestCase):
         with self.assertRaises(ImmutableKeyError):
             self.ts.get_indexed('test_mutable', 'a')
 
-    def test_namespace_indexed(self):
+    def test_namespace_indexed(self) -> None:
         self.ts.set_indexed('test_indexed', 'a', 1)
         self.assertEqual(self.ns.get('test_indexed'), {'a': 1})
         self.assertEqual(self.ns.get_indexed('test_indexed', 'a'), 1)
@@ -581,7 +581,7 @@ class TestTelescopeState(unittest.TestCase):
 
 
 class TestTelescopeStateRedis(TestTelescopeState):
-    def make_telescope_state(self):
+    def make_telescope_state(self) -> TelescopeState:
         def make_fakeredis(**kwargs):
             return fakeredis.FakeRedis()
 
@@ -594,7 +594,7 @@ class TestTelescopeStateRedis(TestTelescopeState):
 
 
 class TestTelescopeStateRedisUrl(TestTelescopeState):
-    def make_telescope_state(self):
+    def make_telescope_state(self) -> TelescopeState:
         def make_fakeredis(cls, **kwargs):
             return fakeredis.FakeRedis()
 

--- a/katsdptelstate/utils.py
+++ b/katsdptelstate/utils.py
@@ -18,6 +18,9 @@ import struct
 import math
 import functools
 import enum
+import os
+import sys
+from typing import Tuple, Union
 
 import six
 
@@ -31,9 +34,13 @@ class KeyType(enum.Enum):
 # Behave gracefully in case someone uses non-UTF-8 binary in a key on PY3
 ensure_str = functools.partial(six.ensure_str, errors='surrogateescape')
 ensure_binary = functools.partial(six.ensure_binary, errors='surrogateescape')
+if sys.version_info >= (3, 6):
+    _PathType = Union[bytes, str, os.PathLike]
+else:
+    _PathType = Union[bytes, str]
 
 
-def display_str(s):
+def display_str(s) -> str:
     """Return most human-readable and yet accurate version of *s*."""
     try:
         return '{!r}'.format(six.ensure_str(s))
@@ -41,7 +48,7 @@ def display_str(s):
         return '{!r}'.format(s)
 
 
-def pack_query_timestamp(time, is_end, include_end=False):
+def pack_query_timestamp(time: float, is_end: bool, include_end: bool = False) -> bytes:
     """Create a query value for a ZRANGEBYLEX query.
 
     When packing the time for the start of a range, set `is_end` and
@@ -65,14 +72,14 @@ def pack_query_timestamp(time, is_end, include_end=False):
         return (b'(' if is_end else b'[') + packed_time
 
 
-def pack_timestamp(timestamp):
+def pack_timestamp(timestamp: float) -> bytes:
     """Encode a timestamp to a bytes that sorts correctly"""
     assert timestamp >= 0
     # abs forces -0 to +0, which encodes differently
     return struct.pack('>d', abs(timestamp))
 
 
-def split_timestamp(packed):
+def split_timestamp(packed: bytes) -> Tuple[bytes, float]:
     """Split out the value and timestamp from a packed item.
 
     The item contains 8 bytes with the timestamp in big-endian IEEE-754

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,3 @@
+[mypy]
+python_version = 3.5
+ignore_missing_imports = True

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(name='katsdptelstate',
       author='MeerKAT SDP team',
       author_email='sdpdev+katsdptelstate@ska.ac.za',
       packages=find_packages(),
-      package_data={'': ['lua_scripts/*.lua']},
+      package_data={'': ['lua_scripts/*.lua', 'py.typed']},
       url='https://github.com/ska-sa/katsdptelstate',
       license='Modified BSD',
       classifiers=[
@@ -55,4 +55,6 @@ setup(name='katsdptelstate',
       install_requires=['redis>=3.3', 'six>=1.12', 'netifaces',
                         'msgpack', 'numpy'],
       extras_require={'rdb': ['rdbtools', 'python-lzf']},
-      tests_require=['rdbtools', 'fakeredis[lua]>=1.3.1'])
+      tests_require=['rdbtools', 'fakeredis[lua]>=1.3.1'],
+      zip_safe=False     # For py.typed
+)

--- a/setup.py
+++ b/setup.py
@@ -57,4 +57,4 @@ setup(name='katsdptelstate',
       extras_require={'rdb': ['rdbtools', 'python-lzf']},
       tests_require=['rdbtools', 'fakeredis[lua]>=1.3.1'],
       zip_safe=False     # For py.typed
-)
+      )


### PR DESCRIPTION
I'd sprinkled a few on to new code, but now I've gone through and done it properly. I wanted to do this now before doing async telstate, because async telstate is going to start by copying a lot of code then sprinkling `async`s and `await`s on it, so it's less effort to do this first than try to add the annotations to both sync and async versions.