### PR TITLE
Stop throwing InvalidKeyError

### DIFF
--- a/katsdptelstate/errors.py
+++ b/katsdptelstate/errors.py
@@ -39,7 +39,10 @@ class RdbParseError(TelstateError):
 
 
 class InvalidKeyError(TelstateError):
-    """A key collides with a class attribute"""
+    """A key collides with a class attribute.
+
+    This is kept only for backwards compatibility. It is no longer considered an error.
+    """
 
 
 class InvalidTimestampError(TelstateError):

--- a/katsdptelstate/test/test_telescope_state.py
+++ b/katsdptelstate/test/test_telescope_state.py
@@ -24,7 +24,7 @@ from unittest import mock
 import numpy as np
 import fakeredis
 
-from katsdptelstate import (TelescopeState, InvalidKeyError, ImmutableKeyError,
+from katsdptelstate import (TelescopeState, ImmutableKeyError,
                             TimeoutError, CancelledError, encode_value, KeyType,
                             ENCODING_MSGPACK)
 from katsdptelstate.memory import MemoryBackend
@@ -73,14 +73,6 @@ class TestTelescopeState(unittest.TestCase):
         self.assertEqual(self.ts[self.ts.join('ns', 'test_key')], 1234.5)
         with self.assertRaises(KeyError):
             self.ts['test_key']
-
-    def test_method_protection(self) -> None:
-        with self.assertRaises(InvalidKeyError):
-            self.ts.add('get', 1234.5)
-        with self.assertRaises(InvalidKeyError):
-            self.ts['get'] = 1234.5
-        with self.assertRaises(InvalidKeyError):
-            self.ts.set_indexed('get', 'sub', 1)
 
     def test_delete(self) -> None:
         self.ts.add('test_key', 1234.5)


### PR DESCRIPTION
Since keys can be (and generally are) accessed by `__getitem__` rather
than `__getattr__`, it is not necessary to disallow using telstate keys
that happen to match method names. It's also problematic because adding
a new method breaks backwards compatibility as it makes a previously
valid key become invalid; and it will become more problematic if we add
additional clients (e.g. asyncio support) as the set of invalid keys
will depend on the interface used.

Remove the check from `add` and `__setitem__`. I've left a check in
`__setattr__` since if an attribute is set with `__setattr__` then it
will likely be retrieved again with `__getattr__` which won't work. The
check has also been improved to check for class members at all levels of
the object's class hierarchy, not just the most-derived class.

I've left the InvalidKeyError exception class in place to avoid breaking
code that catches it, but it will not be thrown.