### PR TITLE
Deal with redis-py deprecating HMSET

### DIFF
--- a/katsdptelstate/redis.py
+++ b/katsdptelstate/redis.py
@@ -74,10 +74,9 @@ class RedisCallback(BackendCallback):
 
     def end_hash(self, key: bytes) -> None:
         self.client_busy = True
-        # redis-py's hset doesn't support multiple key/value pairs, and its
-        # hmset takes a mapping rather than interleaved keys and values. To
-        # avoid the cost of building a dict and then flattening it again,
-        # we execute the raw Redis command directly.
+        # redis-py's hset takes a mapping rather than interleaved keys and
+        # values. To avoid the cost of building a dict and then flattening it
+        # again, we execute the raw Redis command directly.
         self.client.execute_command('HSET', key, *self._hash)
         self.client_busy = False
         self._hash = []

--- a/katsdptelstate/test/test_rdb_handling.py
+++ b/katsdptelstate/test/test_rdb_handling.py
@@ -20,6 +20,7 @@ import unittest
 import shutil
 import os
 import tempfile
+from distutils.version import LooseVersion
 from typing import Mapping, Iterable, BinaryIO, Optional, Union
 
 import redis
@@ -147,7 +148,12 @@ class TestRDBHandling(unittest.TestCase):
     #     self._test_zset([(b'%03d' % i) + b'?' * 500000000 for i in range(10)])
 
     def _test_hash(self, items: Mapping[bytes, bytes]) -> None:
-        self.tr.hmset('my_hash', items)
+        # redis-py 3.5 implements multi-item hset and deprecates hmset.
+        # Use whichever version will work and avoid a warning.
+        if redis.__version__ >= LooseVersion('3.5'):     # type: ignore
+            self.tr.hset('my_hash', mapping=items)
+        else:
+            self.tr.hmset('my_hash', items)
         with RDBWriter(self.base('hash.rdb')) as rdbw:
             rdbw.save(self.tr)
 


### PR DESCRIPTION
Redis-py 3.5 complains if you call hmset, but earlier versions didn't
support multiple keys via hset. To keep support for older versions,
detect the version and use the appropriate function (only affects unit
tests).