### PR TITLE
Improve wait_keys for memory backend

### DIFF
--- a/katsdptelstate/aio/backend.py
+++ b/katsdptelstate/aio/backend.py
@@ -15,7 +15,6 @@
 ################################################################################
 
 from abc import ABC, abstractmethod
-import asyncio
 from typing import List, Tuple, Dict, Iterable, AsyncGenerator, Optional, Union
 
 from ..utils import KeyType
@@ -161,16 +160,14 @@ class Backend(ABC):
     async def dump(self, key: bytes) -> Optional[bytes]:
         """Return a key in the same format as the Redis DUMP command, or None if not present."""
 
+    @abstractmethod
     async def monitor_keys(self, keys: Iterable[bytes]) -> AsyncGenerator[KeyUpdateBase, None]:
         """Report changes to keys in `keys`.
 
         Returns an asynchronous iterator that yields an infinite stream of
         update notifications. When no longer needed it should be closed.
         """
-        # This is a valid but usually suboptimal implementation
-        while True:
-            await asyncio.sleep(1)
-            yield KeyUpdateBase()
+        yield KeyUpdateBase()
 
     @abstractmethod
     def close(self) -> None:

--- a/katsdptelstate/aio/backend.py
+++ b/katsdptelstate/aio/backend.py
@@ -16,7 +16,6 @@
 
 from abc import ABC, abstractmethod
 import asyncio
-import time
 from typing import List, Tuple, Dict, Iterable, AsyncGenerator, Optional, Union
 
 from ..utils import KeyType
@@ -171,11 +170,6 @@ class Backend(ABC):
         # This is a valid but usually suboptimal implementation
         while True:
             await asyncio.sleep(1)
-            yield KeyUpdateBase()
-        timeout = yield None
-        while True:
-            assert timeout is not None
-            time.sleep(timeout)
             yield KeyUpdateBase()
 
     @abstractmethod

--- a/katsdptelstate/aio/backend.py
+++ b/katsdptelstate/aio/backend.py
@@ -167,7 +167,8 @@ class Backend(ABC):
         Returns an asynchronous iterator that yields an infinite stream of
         update notifications. When no longer needed it should be closed.
         """
-        yield KeyUpdateBase()
+        # Just so that this is recognised as a generator
+        yield KeyUpdateBase()     # pragma: nocover
 
     @abstractmethod
     def close(self) -> None:

--- a/katsdptelstate/backend.py
+++ b/katsdptelstate/backend.py
@@ -15,7 +15,6 @@
 ################################################################################
 
 from abc import ABC, abstractmethod
-import time
 from typing import List, Tuple, Dict, Generator, BinaryIO, Iterable, Optional, Union
 
 from .utils import KeyType, _PathType
@@ -221,6 +220,7 @@ class Backend(ABC):
     def dump(self, key: bytes) -> Optional[bytes]:
         """Return a key in the same format as the Redis DUMP command, or None if not present."""
 
+    @abstractmethod
     def monitor_keys(self, keys: Iterable[bytes]) \
             -> Generator[Optional[KeyUpdateBase], Optional[float], None]:
         """Report changes to keys in `keys`.
@@ -237,9 +237,4 @@ class Backend(ABC):
 
         The generator runs until it is closed.
         """
-        # This is a valid but usually suboptimal implementation
-        timeout = yield None
-        while True:
-            assert timeout is not None
-            time.sleep(timeout)
-            timeout = yield KeyUpdateBase()
+        yield None

--- a/katsdptelstate/backend.py
+++ b/katsdptelstate/backend.py
@@ -237,4 +237,5 @@ class Backend(ABC):
 
         The generator runs until it is closed.
         """
-        yield None
+        # Just so that this is recognised as a generator
+        yield None        # pragma: nocover

--- a/katsdptelstate/backend.py
+++ b/katsdptelstate/backend.py
@@ -225,10 +225,12 @@ class Backend(ABC):
             -> Generator[Optional[KeyUpdateBase], Optional[float], None]:
         """Report changes to keys in `keys`.
 
-        Returns a generator. The first yield from the generator is a no-op.
-        After that, the caller sends a timeout and gets back an update event
-        (of type :class:`KeyUpdateBase` or a subclass). If there is no event
-        within the timeout, returns ``None``.
+        Returns a generator. The first yield from the generator may be either
+        ``None`` or an instance of :class:`KeyUpdateBase`; in the latter case,
+        the caller should immediately check the condition again. After that,
+        the caller sends a timeout and gets back an update event (of type
+        :class:`KeyUpdateBase` or a subclass). If there is no event within the
+        timeout, returns ``None``.
 
         It is acceptable (but undesirable) for this function to miss the
         occasional update e.g. due to a network connection outage. The caller

--- a/katsdptelstate/memory.py
+++ b/katsdptelstate/memory.py
@@ -17,12 +17,14 @@
 import bisect
 import re
 import logging
+import contextlib
+import threading
 from datetime import datetime
-from typing import Pattern, List, Tuple, Dict, BinaryIO, Union, Optional
+from typing import Pattern, List, Tuple, Dict, Generator, Iterable, BinaryIO, Union, Optional
 
 from . import utils
 from .utils import _PathType
-from .backend import Backend
+from .backend import Backend, KeyUpdateBase
 from .errors import ImmutableKeyError
 from .rdb_utility import dump_string, dump_zset, dump_hash
 try:
@@ -144,99 +146,126 @@ class MemoryBackend(Backend):
     Write operations are supported only to facilitate testing, but are not
     intended for production use. For that, use a
     :class:`~katsdptelstate.redis.RedisBackend` with an in-memory Redis
-    emulation. The :meth:`monitor_keys` method is not implemented.
+    emulation.
 
     Mutable keys are stored as sorted lists, and encode timestamps in-place
     using the same packing as :class:`~katsdptelstate.redis.RedisBackend`.
     """
     def __init__(self) -> None:
         self._data = {}       # type: Dict[bytes, _Value]
+        self._generation = 0  # incremented each time a change is made
+        self._condition = threading.Condition()
+
+    @contextlib.contextmanager
+    def _write(self) -> Generator[None, None, None]:
+        """Context manager to use for writes."""
+        with self._condition:
+            yield
+            self._generation += 1
+            self._condition.notify_all()
+
+    @contextlib.contextmanager
+    def _read(self) -> Generator[None, None, None]:
+        """Context manager to use for reads."""
+        with self._condition:
+            yield
 
     def load_from_file(self, file: Union[_PathType, BinaryIO]) -> int:
         if rdb_reader is None:
             raise _rdb_reader_import_error   # noqa: F821
-        return rdb_reader.load_from_file(MemoryCallback(self._data), file)
+        with self._write():
+            return rdb_reader.load_from_file(MemoryCallback(self._data), file)
 
     def __contains__(self, key: bytes) -> bool:
-        return key in self._data
+        with self._read():
+            return key in self._data
 
     def keys(self, filter: bytes) -> List[bytes]:
-        if filter == b'*':
-            return list(self._data.keys())
-        else:
-            regex = _compile_pattern(filter)
-            return [key for key in self._data.keys() if regex.match(key)]
+        with self._read():
+            if filter == b'*':
+                return list(self._data.keys())
+            else:
+                regex = _compile_pattern(filter)
+                return [key for key in self._data.keys() if regex.match(key)]
 
     def delete(self, key: bytes) -> None:
-        self._data.pop(key, None)
+        with self._write():
+            self._data.pop(key, None)
 
     def clear(self) -> None:
-        self._data.clear()
+        with self._write():
+            self._data.clear()
 
     def key_type(self, key: bytes) -> Optional[utils.KeyType]:
-        value = self._data.get(key)
-        if value is None:
-            return None
-        elif isinstance(value, bytes):
-            return utils.KeyType.IMMUTABLE
-        elif isinstance(value, dict):
-            return utils.KeyType.INDEXED
-        elif isinstance(value, list):
-            return utils.KeyType.MUTABLE
-        else:
-            assert False
+        with self._read():
+            value = self._data.get(key)
+            if value is None:
+                return None
+            elif isinstance(value, bytes):
+                return utils.KeyType.IMMUTABLE
+            elif isinstance(value, dict):
+                return utils.KeyType.INDEXED
+            elif isinstance(value, list):
+                return utils.KeyType.MUTABLE
+            else:
+                assert False
 
     def set_immutable(self, key: bytes, value: bytes) -> Optional[bytes]:
-        old = self._data.get(key)
-        if old is None:
-            self._data[key] = value
-            return None
-        elif isinstance(old, bytes):
-            return old
-        else:
-            raise ImmutableKeyError
+        with self._write():
+            old = self._data.get(key)
+            if old is None:
+                self._data[key] = value
+                return None
+            elif isinstance(old, bytes):
+                return old
+            else:
+                raise ImmutableKeyError
 
     def get(self, key: bytes) -> Union[
             Tuple[None, None],
             Tuple[bytes, None],
             Tuple[bytes, float],
             Tuple[Dict[bytes, bytes], None]]:
-        value = self._data.get(key)
-        if isinstance(value, list):
-            return utils.split_timestamp(value[-1])
-        else:
-            # mypy is not smart enough to figure out that this is compatible
-            return value, None     # type: ignore
+        with self._read():
+            value = self._data.get(key)
+            if isinstance(value, list):
+                return utils.split_timestamp(value[-1])
+            else:
+                # mypy is not smart enough to figure out that this is compatible
+                return value, None     # type: ignore
 
     def add_mutable(self, key: bytes, value: bytes, timestamp: float) -> None:
-        str_val = utils.pack_timestamp(timestamp) + value
-        items = self._data.get(key)
-        if items is None:
-            self._data[key] = [str_val]
-        elif isinstance(items, list):
-            # To match redis behaviour, we need to avoid inserting the item
-            # if it already exists.
-            pos = bisect.bisect_left(items, str_val)
-            if pos == len(items) or items[pos] != str_val:
-                items.insert(pos, str_val)
-        else:
-            raise ImmutableKeyError
+        with self._write():
+            str_val = utils.pack_timestamp(timestamp) + value
+            items = self._data.get(key)
+            if items is None:
+                self._data[key] = [str_val]
+            elif isinstance(items, list):
+                # To match redis behaviour, we need to avoid inserting the item
+                # if it already exists.
+                pos = bisect.bisect_left(items, str_val)
+                if pos == len(items) or items[pos] != str_val:
+                    items.insert(pos, str_val)
+            else:
+                raise ImmutableKeyError
 
     def set_indexed(self, key: bytes, sub_key: bytes, value: bytes) -> Optional[bytes]:
-        item = self._data.setdefault(key, {})
-        if not isinstance(item, dict):
-            raise ImmutableKeyError
-        if sub_key in item:
-            return item[sub_key]
-        else:
-            item[sub_key] = value
-            return None
+        with self._write():
+            item = self._data.setdefault(key, {})
+            if not isinstance(item, dict):
+                raise ImmutableKeyError
+            if sub_key in item:
+                return item[sub_key]
+            else:
+                item[sub_key] = value
+                return None
 
     def get_indexed(self, key: bytes, sub_key: bytes) -> Optional[bytes]:
-        item = self._data[key]
-        if not isinstance(item, dict):
-            raise ImmutableKeyError
-        return item.get(sub_key)
+        with self._read():
+            item = self._data[key]
+            if not isinstance(item, dict):
+                raise ImmutableKeyError
+            return item.get(sub_key)
 
     @classmethod
     def _bisect(cls, items: List[bytes], timestamp: float,
@@ -252,27 +281,41 @@ class MemoryBackend(Backend):
 
     def get_range(self, key: bytes, start_time: float, end_time: float,
                   include_previous: bool, include_end: bool) -> Optional[List[Tuple[bytes, float]]]:
-        items = self._data.get(key)
-        if items is None:
-            return None
-        elif not isinstance(items, list):
-            raise ImmutableKeyError
+        with self._read():
+            items = self._data.get(key)
+            if items is None:
+                return None
+            elif not isinstance(items, list):
+                raise ImmutableKeyError
 
-        start_pos = self._bisect(items, start_time, False)
-        if include_previous and start_pos > 0:
-            start_pos -= 1
-        end_pos = self._bisect(items, end_time, True, include_end)
-        return [utils.split_timestamp(value) for value in items[start_pos:end_pos]]
+            start_pos = self._bisect(items, start_time, False)
+            if include_previous and start_pos > 0:
+                start_pos -= 1
+            end_pos = self._bisect(items, end_time, True, include_end)
+            return [utils.split_timestamp(value) for value in items[start_pos:end_pos]]
 
     def dump(self, key: bytes) -> Optional[bytes]:
-        value = self._data.get(key)
-        if value is None:
-            return None
-        elif isinstance(value, bytes):
-            return dump_string(value)
-        elif isinstance(value, list):
-            return dump_zset(value)
-        elif isinstance(value, dict):
-            return dump_hash(value)
-        else:
-            assert False
+        with self._read():
+            value = self._data.get(key)
+            if value is None:
+                return None
+            elif isinstance(value, bytes):
+                return dump_string(value)
+            elif isinstance(value, list):
+                return dump_zset(value)
+            elif isinstance(value, dict):
+                return dump_hash(value)
+            else:
+                assert False
+
+    def monitor_keys(self, keys: Iterable[bytes]) \
+            -> Generator[Optional[KeyUpdateBase], Optional[float], None]:
+        with self._condition:
+            timeout = yield None
+            generation = self._generation
+            while True:
+                assert timeout is not None
+                if self._condition.wait_for(lambda: self._generation > generation, timeout):
+                    timeout = yield KeyUpdateBase()
+                else:
+                    timeout = yield None

--- a/katsdptelstate/memory.py
+++ b/katsdptelstate/memory.py
@@ -230,6 +230,10 @@ class MemoryBackend(Backend):
             value = self._data.get(key)
             if isinstance(value, list):
                 return utils.split_timestamp(value[-1])
+            elif isinstance(value, dict):
+                # Have to copy because once we exit the _read context manager
+                # the dictionary could be mutated under us.
+                return dict(value), None
             else:
                 # mypy is not smart enough to figure out that this is compatible
                 return value, None     # type: ignore

--- a/katsdptelstate/telescope_state.py
+++ b/katsdptelstate/telescope_state.py
@@ -507,7 +507,9 @@ class TelescopeState(TelescopeStateBase[Backend]):
         monitor = self._backend.monitor_keys([prefix + key
                                               for prefix in self._prefixes])
         with contextlib.closing(monitor):
-            monitor.send(None)   # Just to start the generator going
+            message = monitor.send(None)   # Just to start the generator going
+            if message and self._check_condition(key, condition):
+                return
             start = time.time()
             while True:
                 # redis-py automatically reconnects to the server if the connection
@@ -626,7 +628,9 @@ class TelescopeState(TelescopeStateBase[Backend]):
         monitor = self._backend.monitor_keys([prefix + key
                                               for prefix in self._prefixes])
         with contextlib.closing(monitor):
-            monitor.send(None)   # Just to start the generator going
+            message = monitor.send(None)   # Just to start the generator going
+            if message is not None and self._check_indexed_condition(key, sub_key_enc, condition):
+                return
             start = time.time()
             while True:
                 check_cancelled()


### PR DESCRIPTION
It used a fallback which just polled for updates once a second, which was not very responsive and could slow down unit tests. Instead, bump a condition variable every time the storage is modified. A side benefit is that the memory backend is now thread-safe.