### PR TITLE
Avoid blocking the Redis server on deletions

### DIFF
--- a/katsdptelstate/aio/redis.py
+++ b/katsdptelstate/aio/redis.py
@@ -152,10 +152,10 @@ class RedisBackend(Backend):
         return await self._execute(self.client.keys, filter)
 
     async def delete(self, key: bytes) -> None:
-        await self._execute(self.client.delete, key)
+        await self._execute(self.client.unlink, key)
 
     async def clear(self) -> None:
-        await self._execute(self.client.flushdb)
+        await self._execute(self.client.flushdb, async_op=True)
 
     async def key_type(self, key: bytes) -> Optional[KeyType]:
         type_ = await self._execute(self.client.type, key)

--- a/katsdptelstate/redis.py
+++ b/katsdptelstate/redis.py
@@ -144,10 +144,11 @@ class RedisBackend(Backend):
 
     def delete(self, key: bytes) -> None:
         # ignore due to typeshed bug: https://github.com/python/typeshed/pull/3969
-        self.client.delete(key)                  # type: ignore
+        self.client.unlink(key)                  # type: ignore
 
     def clear(self) -> None:
-        self.client.flushdb()
+        # typeshed doesn't know about the asynchronous argument
+        self.client.flushdb(asynchronous=True)   # type: ignore
 
     def key_type(self, key: bytes) -> Optional[KeyType]:
         type_ = self.client.type(key)


### PR DESCRIPTION
I was having issues with `telstate.clear` hitting the socket timeout.
Replaced FLUSHDB with FLUSHDB ASYNC and DELETE with UNLINK, which have
the same semantics in Redis but reclaim the memory asynchronously.