### PR TITLE
Multiplex aio pubsubs over pool's standard connection

### DIFF
--- a/katsdptelstate/aio/redis.py
+++ b/katsdptelstate/aio/redis.py
@@ -306,7 +306,6 @@ class RedisBackend(Backend):
                         channel.queues.add(queue)
                     if new_channels:
                         await self.client.subscribe(*new_channels)
-                        new_channels = []
                 # Condition may have been satisfied while we were busy subscribing
                 logger.debug('Subscribed to channels, notifying caller to check')
                 yield KeyUpdateBase()
@@ -360,7 +359,6 @@ class RedisBackend(Backend):
                     # We don't need to wait until redis confirms that the
                     # unsubscription has taken effect, so fire and forget.
                     asyncio.ensure_future(self.client.unsubscribe(*close_channels))
-                    close_channels = []
             await asyncio.sleep(1)
 
     async def dump(self, key: bytes) -> Optional[bytes]:


### PR DESCRIPTION
The previous approach would consume a connection from the pool for every
concurrent use of monitor_keys; with the default of 10 that proved
insufficient.

Instead, use the built-in pub-sub connection provided by the pool for
all pub-sub commands. This is more complex, because
(a) multiple calls to monitor_keys may watch the same key (handled by
using a custom pubsub Channel with a set of queues to broadcast to).
(b) we need to unsubscribe from channels only once there are no further
users.

I think this should be safe, but there are some headache-inducing corner
cases due to the windows between issuing a (un)subscription and getting
the response. The channel only appears in
self.client.connection.pubsub_channels after aioredis has processed the
response. So for example that we'll see an existing channel and start
to use it, while at the same time it's being unsubscribed. Fortunately
aioredis notifies the channel when the unsubscription arrives, so it can
poison the queues and trigger monitor_keys to go around the loop again.

Closes SPR1-644.