### PR TITLE
Limit aioredis to <2.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(name='katsdptelstate',
                         'msgpack', 'numpy'],
       extras_require={
           'rdb': ['rdbtools', 'python-lzf'],
-          'aio': ['aioredis'],
+          'aio': ['aioredis<2'],
           'test': tests_require
       },
       tests_require=tests_require,


### PR DESCRIPTION
The next release of aioredis will apparently [contain breaking
changes](https://github.com/aio-libs/aioredis/issues/784#issuecomment-727247717),
so we should avoid installing it until we know what those are.