### PR TITLE
Use a dedicated thread for async MemoryBackend.monitor_keys

### DIFF
--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -13,7 +13,7 @@ idna==2.8                 # via requests
 imagesize==1.1.0          # via sphinx
 jinja2==2.10.1            # via sphinx
 markupsafe==1.1.1         # via jinja2
-packaging==19.0           # via sphinx
+packaging==20.1           # via sphinx
 pygments==2.4.2           # via sphinx
 pyparsing==2.4.0          # via packaging
 pytz==2019.1              # via babel


### PR DESCRIPTION
The monitoring process takes an unbounded amount of time, so if run on
the default thread pool executor it can tie up all the available
threads.

This has the potential to create a larger-than-ideal number of threads,
but monitoring keys on a memory backend is only really useful for unit
tests.