### PR TITLE
Requirements cleanup

### DIFF
--- a/doc-requirements.in
+++ b/doc-requirements.in
@@ -1,2 +1,4 @@
-Sphinx
+-c https://raw.githubusercontent.com/ska-sa/katsdpdockerbase/master/docker-base-build/base-requirements.txt
+
+sphinx
 sphinx_rtd_theme

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "wheel", "katversion"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
+-c https://raw.githubusercontent.com/ska-sa/katsdpdockerbase/master/docker-base-build/base-requirements.txt
+
 aioredis
-async_timeout           # via aioredis
-hiredis                 # via aioredis
 msgpack
 netifaces
 numpy

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,5 @@
--c https://raw.githubusercontent.com/ska-sa/katsdpdockerbase/master/docker-base-build/base-requirements.txt
+# TODO: change to -d and unpin fakeredis once katsdpdockerbase updates fakeredis
+-d https://raw.githubusercontent.com/ska-sa/katsdpdockerbase/master/docker-base-build/base-requirements.txt
 
 asynctest
 async_timeout
@@ -7,4 +8,4 @@ fakeredis[lua,aioredis]==1.4.1
 lupa==1.9                  # via fakeredis[lua]
 nose
 python-lzf==0.2.4
-rdbtools==0.1.12
+rdbtools

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,8 +1,10 @@
+-c https://raw.githubusercontent.com/ska-sa/katsdpdockerbase/master/docker-base-build/base-requirements.txt
+
 asynctest
+async_timeout
 coverage
-fakeredis==1.4.1
+fakeredis[lua,aioredis]==1.4.1
 lupa==1.9                  # via fakeredis[lua]
 nose
 python-lzf==0.2.4
 rdbtools==0.1.12
-sortedcontainers==2.1.0    # via fakeredis


### PR DESCRIPTION
- Use -c options to specify base versions
- Add async_timeout to test-requirements.txt
- Add extras to requirements files

See SPR1-833.