### PR TITLE
Switch to aioredis 2.x

### DIFF
--- a/katsdptelstate/aio/rdb_writer.py
+++ b/katsdptelstate/aio/rdb_writer.py
@@ -53,8 +53,8 @@ class RDBWriter(RDBWriterBase):
             client = client.backend
         if keys is None:
             logger.info("No keys specified - dumping entire database")
-            keys = await client.keys(b'*')
+            keys = await client.keys(b'*')  # type: ignore
         for key in keys:
             key = ensure_binary(key)
-            dumped_value = await client.dump(key)
+            dumped_value = await client.dump(key)  # type: ignore
             self.write_key(key, dumped_value)

--- a/katsdptelstate/aio/rdb_writer.py
+++ b/katsdptelstate/aio/rdb_writer.py
@@ -53,8 +53,8 @@ class RDBWriter(RDBWriterBase):
             client = client.backend
         if keys is None:
             logger.info("No keys specified - dumping entire database")
-            keys = await client.keys(b'*')  # type: ignore
+            keys = await client.keys(b'*')
         for key in keys:
             key = ensure_binary(key)
-            dumped_value = await client.dump(key)  # type: ignore
+            dumped_value = await client.dump(key)
             self.write_key(key, dumped_value)

--- a/katsdptelstate/aio/redis.py
+++ b/katsdptelstate/aio/redis.py
@@ -71,14 +71,7 @@ class _Command:
 
 
 class RedisBackend(Backend):
-    """Backend for :class:`TelescopeState` using redis for storage.
-
-    .. warning::
-
-        Different backends must not share the same redis connection pool. It
-        will mostly work, but will break down if they try to use pub/sub to
-        monitor the same keys.
-    """
+    """Backend for :class:`TelescopeState` using redis for storage."""
 
     _KEY_TYPES = {
         b'none': None,

--- a/katsdptelstate/aio/redis.py
+++ b/katsdptelstate/aio/redis.py
@@ -100,7 +100,7 @@ class RedisBackend(Backend):
                             'add_mutable']:
             script = pkg_resources.resource_string(
                 'katsdptelstate', 'lua_scripts/{}.lua'.format(script_name))
-            self._scripts[script_name] = self.client.register_script(script)  # type: ignore
+            self._scripts[script_name] = self.client.register_script(script)
 
     async def _execute(self, call: Callable[..., Awaitable], *args, **kwargs) -> Any:
         """Execute a redis command, retrying if the connection died.
@@ -191,11 +191,11 @@ class RedisBackend(Backend):
         """Internal part of :meth:`get_range` that is retried if the connection fails."""
         with _handle_wrongtype():
             async with self.client.pipeline() as pipe:
-                pipe.exists(key)  # type: ignore
+                pipe.exists(key)
                 if include_previous and packed_st != b'-':
-                    pipe.zrevrangebylex(key, packed_st, b'-', start=0, num=1)  # type: ignore
+                    pipe.zrevrangebylex(key, packed_st, b'-', start=0, num=1)
                 if packed_st != b'+' and packed_et != b'-':
-                    pipe.zrangebylex(key, packed_st, packed_et)  # type: ignore
+                    pipe.zrangebylex(key, packed_st, packed_et)
                 # raise_on_error annotates the exception message, which breaks
                 # the _handle_wrongtype detection.
                 ret_vals = await pipe.execute(raise_on_error=False)

--- a/katsdptelstate/aio/redis.py
+++ b/katsdptelstate/aio/redis.py
@@ -302,8 +302,9 @@ class RedisBackend(Backend):
                         # aioredis doesn't automatically reconnect
                         # (see https://github.com/andymccurdy/redis-py/issues/1464).
                         try:
-                            await self._pubsub.connection.disconnect()
-                            await self._pubsub.connection.connect()
+                            if self._pubsub.connection is not None:
+                                await self._pubsub.connection.disconnect()
+                                await self._pubsub.connection.connect()
                         except aioredis.ConnectionError as exc:
                             # Avoid spamming the server with connection attempts
                             logger.warning('redis reconnect attempt failed (%s), trying in 1s', exc)

--- a/katsdptelstate/aio/telescope_state.py
+++ b/katsdptelstate/aio/telescope_state.py
@@ -387,7 +387,8 @@ class TelescopeState(TelescopeStateBase[Backend]):
             If specified, this is used to find the latest value instead of
             retrieving it from the backend.
         """
-        assert message is None or message.sub_key == sub_key
+        if message is not None and message.sub_key != sub_key:
+            return False           # This update is not applicable
         for prefix in self._prefixes:
             full_key = prefix + key
             if message is not None and full_key == message.key:

--- a/katsdptelstate/aio/test/test_telescope_state.py
+++ b/katsdptelstate/aio/test/test_telescope_state.py
@@ -388,7 +388,7 @@ class TestTelescopeState(asynctest.TestCase):
         # so we need to sleep a bit to let them take place.
         if isinstance(self.ts.backend, RedisBackend):
             await asyncio.sleep(0.1)
-            self.assertEqual(self.ts.backend.client.connection.pubsub_channels, {})
+            self.assertEqual(self.ts.backend._pubsub.channels, {})  # type: ignore
 
     async def test_wait_key_concurrent_same(self) -> None:
         task1 = asyncio.ensure_future(self.ts.wait_key('key'))
@@ -403,7 +403,7 @@ class TestTelescopeState(asynctest.TestCase):
         # so we need to sleep a bit to let them take place.
         if isinstance(self.ts.backend, RedisBackend):
             await asyncio.sleep(0.1)
-            self.assertEqual(self.ts.backend.client.connection.pubsub_channels, {})
+            self.assertEqual(self.ts.backend._pubsub.channels, {})  # type: ignore
 
     async def test_wait_indexed_already_done(self) -> None:
         await self.ts.set_indexed('test_key', 'sub_key', 5)
@@ -424,6 +424,7 @@ class TestTelescopeState(asynctest.TestCase):
 
     async def test_wait_indexed_delayed(self) -> None:
         async def set_key():
+            await asyncio.sleep(0.05)
             await self.ts.set_indexed('test_key', 'foo', 1)
             await asyncio.sleep(0.05)
             await self.ts.set_indexed('test_key', 'bar', 2)
@@ -548,7 +549,7 @@ class TestTelescopeState(asynctest.TestCase):
 
 class TestTelescopeStateRedis(TestTelescopeState):
     async def make_telescope_state(self) -> TelescopeState:
-        client = await fakeredis.aioredis.create_redis_pool()
+        client = await fakeredis.aioredis.FakeRedis()
         return TelescopeState(RedisBackend(client))
 
 

--- a/katsdptelstate/aio/test/test_telescope_state.py
+++ b/katsdptelstate/aio/test/test_telescope_state.py
@@ -388,7 +388,7 @@ class TestTelescopeState(asynctest.TestCase):
         # so we need to sleep a bit to let them take place.
         if isinstance(self.ts.backend, RedisBackend):
             await asyncio.sleep(0.1)
-            self.assertEqual(self.ts.backend._pubsub.channels, {})  # type: ignore
+            self.assertEqual(self.ts.backend._pubsub.channels, {})
 
     async def test_wait_key_concurrent_same(self) -> None:
         task1 = asyncio.ensure_future(self.ts.wait_key('key'))
@@ -403,7 +403,7 @@ class TestTelescopeState(asynctest.TestCase):
         # so we need to sleep a bit to let them take place.
         if isinstance(self.ts.backend, RedisBackend):
             await asyncio.sleep(0.1)
-            self.assertEqual(self.ts.backend._pubsub.channels, {})  # type: ignore
+            self.assertEqual(self.ts.backend._pubsub.channels, {})
 
     async def test_wait_indexed_already_done(self) -> None:
         await self.ts.set_indexed('test_key', 'sub_key', 5)

--- a/katsdptelstate/telescope_state.py
+++ b/katsdptelstate/telescope_state.py
@@ -555,7 +555,8 @@ class TelescopeState(TelescopeStateBase[Backend]):
             If specified, this is used to find the latest value instead of
             retrieving it from the backend.
         """
-        assert message is None or message.sub_key == sub_key
+        if message is not None and message.sub_key != sub_key:
+            return False           # This update is not applicable
         for prefix in self._prefixes:
             full_key = prefix + key
             if message is not None and full_key == message.key:

--- a/katsdptelstate/test/test_telescope_state.py
+++ b/katsdptelstate/test/test_telescope_state.py
@@ -424,6 +424,7 @@ class TestTelescopeState(unittest.TestCase):
 
     def test_wait_indexed_delayed(self) -> None:
         def set_key():
+            time.sleep(0.05)
             self.ts.set_indexed('test_key', 'foo', 1)
             time.sleep(0.05)
             self.ts.set_indexed('test_key', 'bar', 2)

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setup(name='katsdptelstate',
       ],
       extras_require={
           'rdb': ['rdbtools', 'python-lzf'],
-          'aio': ['aioredis<2'],
+          'aio': ['aioredis>=2.0.0a1'],
           'test': tests_require
       },
       tests_require=tests_require,


### PR DESCRIPTION
This is a breaking change (so don't merge yet), because aioredis 2.x is completely incompatible (it's basically a different library), and any code that uses aioredis to set up a connection to a Redis server will need to be updated to work with version 2.