### PR TITLE
Add aio.redis.RedisBackend.from_url

### DIFF
--- a/katsdptelstate/aio/redis.py
+++ b/katsdptelstate/aio/redis.py
@@ -170,6 +170,16 @@ class RedisBackend(Backend):
                 'katsdptelstate', 'lua_scripts/{}.lua'.format(script_name))
             self._scripts[script_name] = _Script(script)
 
+    @classmethod
+    async def from_url(cls, url: str) -> 'RedisBackend':
+        """Create a backend from a redis URL.
+
+        This is the recommended approach as it ensures that the server is
+        reachable, and sets some timeouts to reasonable values.
+        """
+        client = await aioredis.create_redis_pool(url, timeout=5)
+        return cls(client)
+
     async def _execute(self, call: Callable[..., Awaitable], *args, **kwargs) -> Any:
         """Execute a redis command, retrying if the connection died.
 


### PR DESCRIPTION
This allows clients to use a RedisBackend without knowing anything about
aioredis, and more importantly, without caring which aioredis version is
in place. It also takes care of setting a sensible health check
interval.
