### PR TITLE
Add synchronous RedisBackend.from_url

### DIFF
--- a/katsdptelstate/aio/redis.py
+++ b/katsdptelstate/aio/redis.py
@@ -171,13 +171,13 @@ class RedisBackend(Backend):
             self._scripts[script_name] = _Script(script)
 
     @classmethod
-    async def from_url(cls, url: str) -> 'RedisBackend':
+    async def from_url(cls, url: str, *, db: Optional[int] = None) -> 'RedisBackend':
         """Create a backend from a redis URL.
 
         This is the recommended approach as it ensures that the server is
         reachable, and sets some timeouts to reasonable values.
         """
-        client = await aioredis.create_redis_pool(url, timeout=5)
+        client = await aioredis.create_redis_pool(url, db=db, timeout=5)
         return cls(client)
 
     async def _execute(self, call: Callable[..., Awaitable], *args, **kwargs) -> Any:

--- a/katsdptelstate/redis.py
+++ b/katsdptelstate/redis.py
@@ -126,6 +126,21 @@ class RedisBackend(Backend):
                 'katsdptelstate', 'lua_scripts/{}.lua'.format(script_name))
             self._scripts[script_name] = self.client.register_script(script)
 
+    @classmethod
+    def from_url(cls, url: str, *, db: Optional[int] = None) -> 'RedisBackend':
+        """Create a backend from a redis URL.
+
+        This is the recommended approach as it ensures that the server is
+        reachable, and sets some timeouts to reasonable values.
+        """
+        client = redis.Redis.from_url(
+            url,
+            db=db,
+            socket_timeout=5,
+            health_check_interval=30
+        )
+        return cls(client)
+
     def _call(self, script_name: str, *args, **kwargs) -> Any:
         return self._scripts[script_name](*args, **kwargs)
 

--- a/katsdptelstate/telescope_state.py
+++ b/katsdptelstate/telescope_state.py
@@ -117,11 +117,7 @@ class TelescopeState(TelescopeStateBase[Backend]):
         else:
             from .redis import RedisBackend
             if isinstance(endpoint, str) and '://' in endpoint:
-                r = redis.Redis.from_url(
-                    endpoint,
-                    db=db,
-                    socket_timeout=5,
-                    health_check_interval=30)
+                backend = RedisBackend.from_url(endpoint, db=db)
             else:
                 if not isinstance(endpoint, Endpoint):
                     endpoint = endpoint_parser(default_port=None)(endpoint)
@@ -134,8 +130,7 @@ class TelescopeState(TelescopeStateBase[Backend]):
                 # If no port is provided, redis will pick its default port
                 if endpoint.port is not None:
                     redis_kwargs['port'] = endpoint.port
-                r = redis.Redis(**redis_kwargs)
-            backend = RedisBackend(r)
+                backend = RedisBackend(redis.Redis(**redis_kwargs))
         super().__init__(backend, prefixes, base)
 
     def load_from_file(self, file: Union[_PathType, BinaryIO]) -> int:

--- a/katsdptelstate/test/test_telescope_state.py
+++ b/katsdptelstate/test/test_telescope_state.py
@@ -28,6 +28,7 @@ from katsdptelstate import (TelescopeState, ImmutableKeyError,
                             TimeoutError, CancelledError, encode_value, KeyType,
                             ENCODING_MSGPACK)
 from katsdptelstate.memory import MemoryBackend
+from katsdptelstate.redis import RedisBackend
 
 
 class TestTelescopeState(unittest.TestCase):
@@ -592,6 +593,20 @@ class TestTelescopeStateRedisUrl(TestTelescopeState):
 
         with mock.patch('redis.Redis.from_url', side_effect=make_fakeredis) as mock_redis:
             ts = TelescopeState('redis://example.com', db=1)
+            mock_redis.assert_called_with(
+                'redis://example.com',
+                db=1, socket_timeout=mock.ANY, health_check_interval=mock.ANY)
+        return ts
+
+
+class TestTelescopeStateRedisBackendFromUrl(TestTelescopeState):
+    def make_telescope_state(self) -> TelescopeState:
+        def make_fakeredis(cls, **kwargs):
+            return fakeredis.FakeRedis()
+
+        with mock.patch('redis.Redis.from_url', side_effect=make_fakeredis) as mock_redis:
+            backend = RedisBackend.from_url('redis://example.com', db=1)
+            ts = TelescopeState(backend)
             mock_redis.assert_called_with(
                 'redis://example.com',
                 db=1, socket_timeout=mock.ANY, health_check_interval=mock.ANY)


### PR DESCRIPTION
This is to match the asynchronnous version added in #125. A `db`
argument is added (to both versions) so that the main TelescopeState
constructor can chain to this helper.

The unit test for the asynchronous version was also modified to work
more like the synchronous unit tests.
