### PR TITLE
Fix set_indexed so that wait_indexed actually works

### DIFF
--- a/katsdptelstate/lua_scripts/set_indexed.lua
+++ b/katsdptelstate/lua_scripts/set_indexed.lua
@@ -1,6 +1,6 @@
 if redis.call('HSETNX', KEYS[1], ARGV[1], ARGV[2]) == 1 then
     -- Bundle subkey and value into a single message in a way that allows unpacking
-    local message = "\x03" .. string.len(ARGV[1]) .. "\n" .. ARGV[1] .. ARGV[2]
+    local message = "\003" .. string.len(ARGV[1]) .. "\n" .. ARGV[1] .. ARGV[2]
     redis.call('PUBLISH', 'update/' .. KEYS[1], message)
     return false
 else


### PR DESCRIPTION
The Lua script for set_indexed was using a hex escape `\x03`, which is
only supported from Lua 5.2, and the Lua in redis is Lua 5.1.
