### PR TITLE
Remove multicast_subscribe functionality from endpoint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
-- repo: https://gitlab.com/pycqa/flake8
+- repo: https://github.com/PyCQA/flake8
   rev: 3.9.2
   hooks:
     - id: flake8

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@
 aioredis
 hiredis
 msgpack
-netifaces
 numpy
 redis
 six

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,6 @@ setup(name='katsdptelstate',
       install_requires=[
           'hiredis',          # Not strictly required, but improves performance
           'msgpack',
-          'netifaces',
           'numpy',
           'redis>=3.3',
           'six>=1.12'


### PR DESCRIPTION
This removes the dependency on `netifaces`.

That's good. One less thing.