### PR TITLE
SPR1-2807: Prepare for 0.12

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -1,6 +1,16 @@
 History
 =======
 
+0.12 (2023-03-14)
+-----------------
+* Switch to aioredis 2.x (#124)
+* Add async (and synchronous) `RedisBackend.from_url` constructor (#125, #126)
+* Switch from nose to pytest (#129)
+* Remove `Endpoint.multicast_subscribe` and `netifaces` dependency (#130)
+* Fix Lua script for `set_indexed` so that `wait_indexed` actually works (#127)
+* Make aio `wait_key` more robust (#128)
+* General cleanup (#122, #123)
+
 0.11 (2021-05-07)
 -----------------
 * Add asynchronous RDBWriter class (#108)

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -1,7 +1,7 @@
 History
 =======
 
-0.12 (2023-03-14)
+0.12 (2023-03-13)
 -----------------
 * Switch to aioredis 2.x (#124)
 * Add async (and synchronous) `RedisBackend.from_url` constructor (#125, #126)

--- a/README.rst
+++ b/README.rst
@@ -146,13 +146,12 @@ Example
 
 .. code:: python
 
-  import aioredis
   from katsdptelstate.aio import TelescopeState
   from katsdptelstate.aio.redis import RedisBackend
 
   # Create a connection to localhost redis server
-  client = await aioredis.create_redis_pool('redis://localhost')
-  ts = TelescopeState(RedisBackend(client))
+  backend = await RedisBackend.from_url('redis://localhost')
+  ts = TelescopeState(backend)
 
   # Store and retrieve some data
   await ts.set('key', 'value')

--- a/setup.py
+++ b/setup.py
@@ -27,9 +27,9 @@ news = open(os.path.join(here, 'NEWS.rst')).read()
 long_description = readme + '\n\n' + news
 tests_require = [
     'async_timeout>=1.3.0',
-    'fakeredis[lua,aioredis]>=1.4.0',
+    'fakeredis[lua,aioredis]>=1.6.0,<2',
     'pytest',
-    'pytest-asyncio'
+    'pytest-asyncio>=0.17.0'
 ]
 
 setup(name='katsdptelstate',
@@ -62,7 +62,7 @@ setup(name='katsdptelstate',
           'hiredis',          # Not strictly required, but improves performance
           'msgpack',
           'numpy',
-          'redis>=3.3',
+          'redis>=3.3,<4.2',
           'six>=1.12'
       ],
       extras_require={


### PR DESCRIPTION
This is a stop-gap release just to get the older stuff out (like aioredis 2.x support). In the next v0.13 release [**imminent!** 
 It's waiting in the wings while I went a step back for this 😁] we’ll jump to redis 4.2+ with builtin asyncio support and no more aioredis.

The version restrictions are needed to fix some regressions in the aio unit tests (12 failures in `aio/test/test_telescope_state.py`), involving the following exceptions on immutable and indexed responses:

  - `redis.exceptions.NoScriptError`: No matching script. Please use EVAL.
  - `redis.exceptions.ResponseError`: WRONGTYPE Operation against a key holding the wrong kind of value
  - `TypeError`: 'ResponseError' object is not iterable

This seems to be an interaction between aioredis 2.0.1 and recent redis-py versions.

The restricted versions are also still compatible with the current docker-base, so tests pass. The next release will require docker-base updates.