### PR TITLE
SPR1-2766: Update lupa to 1.14.1

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,9 +3,9 @@
 
 async_timeout
 fakeredis[lua]
-lupa==1.9                  # via fakeredis[lua]
+lupa==1.14.1               # via fakeredis[lua]
 pytest
-pytest-asyncio==0.19.0
+pytest-asyncio==0.20.3
 pytest-cov
 python-lzf==0.2.4
 rdbtools


### PR DESCRIPTION
The firefighting starts 😂 

This is required by fakeredis 2.10.0, which is now in docker base. Also bump pytest-asyncio while we are at it.