### PR TITLE
SPR1-2766: Update lupa to docker base version

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,7 +3,7 @@
 
 async_timeout
 fakeredis[lua]
-lupa==1.14.1               # via fakeredis[lua]
+lupa                       # via fakeredis[lua]
 pytest
 pytest-asyncio==0.20.3
 pytest-cov


### PR DESCRIPTION
It is worthwhile centralising the lupa version since there are two packages using it in their tests (katsdptelstate and katsdpimager).