### PR TITLE
SPR1-3242: Prepare for release 1.0.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2015-2024, National Research Foundation (SARAO)
+Copyright (c) 2015-2025, National Research Foundation (SARAO)
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,3 @@
-exclude Jenkinsfile
-exclude *requirements.txt
-exclude .gitignore
 include Dockerfile
 include redis.conf
 include doc/*

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -1,6 +1,11 @@
 History
 =======
 
+1.0.0 (2025-07-07)
+------------------
+* Admit that we are at version 1.0 by now (#140)
+* Refresh for Python 3.13, NumPy 2.0 and latest fakeredis (#139)
+
 0.14 (2024-02-28)
 -----------------
 * Improvements to internal type hints (#133)

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 ################################################################################
-# Copyright (c) 2015-2024, National Research Foundation (SARAO)
+# Copyright (c) 2015-2025, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/setup.py
+++ b/setup.py
@@ -42,11 +42,10 @@ setup(name='katsdptelstate',
       packages=find_packages(),
       package_data={'': ['lua_scripts/*.lua', 'py.typed']},
       url='https://github.com/ska-sa/katsdptelstate',
-      license='Modified BSD',
+      license='BSD-3-Clause',
       classifiers=[
           'Development Status :: 5 - Production/Stable',
           'Intended Audience :: Developers',
-          'License :: OSI Approved :: BSD License',
           'Operating System :: OS Independent',
           'Programming Language :: Python',
           'Programming Language :: Python :: 3',
@@ -70,6 +69,5 @@ setup(name='katsdptelstate',
           'aio': [],
           'test': tests_require
       },
-      tests_require=tests_require,
       zip_safe=False     # For py.typed
       )


### PR DESCRIPTION
It's time to admit that we should have been 1.0 years ago 😅 

Since there has been no new features or actual bug fixes during the past two years, it is safe to call it 1.0 by now. The past while has only seen maintenance releases to keep up with the changing Python ecosystem.

While running `python3 -m build` I noticed some warnings in the log output, which I've now fixed. I've considered ditching `katversion` but that is probably a slightly larger task left for post 1.0.