### PR TITLE
limit setuptools version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["setuptools", "wheel", "katversion"]
+requires = ["setuptools<=81.0.0", "wheel", "katversion"]


### PR DESCRIPTION
See removed sub-package used by `katversion`  https://github.com/pypa/setuptools/issues/5174